### PR TITLE
Update RISE commit

### DIFF
--- a/experiments/args/rise/client
+++ b/experiments/args/rise/client
@@ -18,7 +18,7 @@ W_METHOD,WP_METHOD
 
 ##### EdhocMapperConfig #####
 -protocolVersion
-v19
+v20
 
 -combinedMessageVersion
 v07

--- a/experiments/args/rise/client_m4_app
+++ b/experiments/args/rise/client_m4_app
@@ -18,7 +18,7 @@ W_METHOD,WP_METHOD
 
 ##### EdhocMapperConfig #####
 -protocolVersion
-v19
+v20
 
 -combinedMessageVersion
 v07

--- a/experiments/args/rise/server
+++ b/experiments/args/rise/server
@@ -17,7 +17,7 @@ W_METHOD,WP_METHOD
 
 ##### EdhocMapperConfig #####
 -protocolVersion
-v19
+v20
 
 -combinedMessageVersion
 v07

--- a/experiments/args/rise/server_m4_app
+++ b/experiments/args/rise/server_m4_app
@@ -17,7 +17,7 @@ W_METHOD,WP_METHOD
 
 ##### EdhocMapperConfig #####
 -protocolVersion
-v19
+v20
 
 -combinedMessageVersion
 v07

--- a/scripts/setup_sul.sh
+++ b/scripts/setup_sul.sh
@@ -35,7 +35,7 @@ setup_edhoc_rs() {
 
 setup_rise() {
   # rise
-  readonly COMMIT_HASH="500f1bea0128e91a1bfee72723a74b4ca565ac02"
+  readonly COMMIT_HASH="d728368ac44dabceff2b4a2c5fcd757552e65f9e"
   readonly PREFIX="${SOURCES_DIR}/californium/cf-edhoc/src"
   readonly POSTFIX="java/org/eclipse/californium/edhoc"
   readonly CF_EDHOC_MAIN_DIR="${PREFIX}/main/${POSTFIX}"


### PR DESCRIPTION
Update to the latest commit, which uses the changes of `v20`. The models are the same as before.