### PR TITLE
Test pdf construction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,7 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - uses: ts-graphviz/setup-graphviz@v1
+      - name: Install pydot
         run: pip3 install pydot
 
       - name: Setup EDHOC-Fuzzer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - uses: ts-graphviz/setup-graphviz@v1
 
       - name: Setup EDHOC-Fuzzer
         run: ./scripts/setup_fuzzer.sh -l
@@ -39,6 +40,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - uses: ts-graphviz/setup-graphviz@v1
 
       - name: Setup EDHOC-Fuzzer
         run: ./scripts/setup_fuzzer.sh -l
@@ -65,6 +67,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - uses: ts-graphviz/setup-graphviz@v1
 
       - name: Setup EDHOC-Fuzzer
         run: ./scripts/setup_fuzzer.sh -l
@@ -88,6 +91,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - uses: ts-graphviz/setup-graphviz@v1
 
       - name: Setup EDHOC-Fuzzer
         run: ./scripts/setup_fuzzer.sh -l
@@ -111,6 +115,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - uses: ts-graphviz/setup-graphviz@v1
 
       - name: Setup EDHOC-Fuzzer
         run: ./scripts/setup_fuzzer.sh -l
@@ -134,6 +139,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - uses: ts-graphviz/setup-graphviz@v1
 
       - name: Setup EDHOC-Fuzzer
         run: ./scripts/setup_fuzzer.sh -l
@@ -157,6 +163,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - uses: ts-graphviz/setup-graphviz@v1
 
       - name: Setup EDHOC-Fuzzer
         run: ./scripts/setup_fuzzer.sh -l
@@ -180,6 +187,8 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - uses: ts-graphviz/setup-graphviz@v1
+        run: pip3 install pydot
 
       - name: Setup EDHOC-Fuzzer
         run: ./scripts/setup_fuzzer.sh -l

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - uses: ts-graphviz/setup-graphviz@v1
+      - name: Install pydot
+        run: pip3 install pydot
 
       - name: Setup EDHOC-Fuzzer
         run: ./scripts/setup_fuzzer.sh -l
@@ -41,6 +43,8 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - uses: ts-graphviz/setup-graphviz@v1
+      - name: Install pydot
+        run: pip3 install pydot
 
       - name: Setup EDHOC-Fuzzer
         run: ./scripts/setup_fuzzer.sh -l
@@ -68,6 +72,8 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - uses: ts-graphviz/setup-graphviz@v1
+      - name: Install pydot
+        run: pip3 install pydot
 
       - name: Setup EDHOC-Fuzzer
         run: ./scripts/setup_fuzzer.sh -l
@@ -92,6 +98,8 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - uses: ts-graphviz/setup-graphviz@v1
+      - name: Install pydot
+        run: pip3 install pydot
 
       - name: Setup EDHOC-Fuzzer
         run: ./scripts/setup_fuzzer.sh -l
@@ -116,6 +124,8 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - uses: ts-graphviz/setup-graphviz@v1
+      - name: Install pydot
+        run: pip3 install pydot
 
       - name: Setup EDHOC-Fuzzer
         run: ./scripts/setup_fuzzer.sh -l
@@ -140,6 +150,8 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - uses: ts-graphviz/setup-graphviz@v1
+      - name: Install pydot
+        run: pip3 install pydot
 
       - name: Setup EDHOC-Fuzzer
         run: ./scripts/setup_fuzzer.sh -l
@@ -164,6 +176,8 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - uses: ts-graphviz/setup-graphviz@v1
+      - name: Install pydot
+        run: pip3 install pydot
 
       - name: Setup EDHOC-Fuzzer
         run: ./scripts/setup_fuzzer.sh -l


### PR DESCRIPTION
This PR extends the CI tests with the ability to generate the PDFs of the beautified learned models (and thereby check the PDF generation and the `beautify_model.sh` script).  Its changes ensure that the `dot` and `pydot` commands are installed when using `edhoc-fuzzer.jar`.