### PR TITLE
Add most missing maven dependencies in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,12 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
-        <protocol-state-fuzzer-version>1.0.0</protocol-state-fuzzer-version>
-        <cf-edhoc-version>0.0.0</cf-edhoc-version>
-        <gson-version>2.10.1</gson-version>
-        <junit-version>4.13.2</junit-version>
+        <protocol-state-fuzzer.version>1.0.0</protocol-state-fuzzer.version>
+        <cf-edhoc.version>0.0.0</cf-edhoc.version>
+        <jaxb-api.version>4.0.0</jaxb-api.version>
+        <jcommander.version>1.82</jcommander.version>
+        <log4j.version>2.20.0</log4j.version>
+        <gson.version>2.10.1</gson.version>
     </properties>
 
     <dependencyManagement>
@@ -25,57 +27,81 @@
             <dependency>
                 <groupId>com.github.protocolfuzzing</groupId>
                 <artifactId>protocolstatefuzzer</artifactId>
-                <version>${protocol-state-fuzzer-version}</version>
+                <version>${protocol-state-fuzzer.version}</version>
             </dependency>
 
             <!-- manually installed cf-edhoc -->
             <dependency>
                 <groupId>se.ri.org.eclipse.californium</groupId>
                 <artifactId>cf-edhoc</artifactId>
-                <version>${cf-edhoc-version}</version>
+                <version>${cf-edhoc.version}</version>
             </dependency>
+
+            <!-- jaxb api -->
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jaxb-api.version}</version>
+            </dependency>
+
+            <!-- jcommander -->
+            <dependency>
+                <groupId>com.beust</groupId>
+                <artifactId>jcommander</artifactId>
+                <version>${jcommander.version}</version>
+            </dependency>
+
+            <!-- log4j -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+           </dependency>
 
             <!-- gson -->
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>${gson-version}</version>
-            </dependency>
-
-            <!-- unit testing dependencies -->
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit-version}</version>
-                <scope>test</scope>
+                <version>${gson.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
         <!-- https://github.com/protocol-fuzzing/protocol-state-fuzzer -->
-            <dependency>
-                <groupId>com.github.protocolfuzzing</groupId>
-                <artifactId>protocolstatefuzzer</artifactId>
-            </dependency>
+        <dependency>
+            <groupId>com.github.protocolfuzzing</groupId>
+            <artifactId>protocolstatefuzzer</artifactId>
+        </dependency>
 
         <!-- manually modified and built jar and locally installed cf-edhoc
-             see ./scripts/setup_fuzzer for more details -->
+             see ./scripts/setup_fuzzer.sh for more details -->
         <dependency>
             <groupId>se.ri.org.eclipse.californium</groupId>
             <artifactId>cf-edhoc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.beust</groupId>
+            <artifactId>jcommander</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/junit/junit -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
 
@@ -143,6 +169,12 @@
                         <phase>package</phase>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.6.0</version>
             </plugin>
 
             <!-- Disable jar:jar run on package phase -->


### PR DESCRIPTION
Eliminate most warnings from missing dependencies when running `mvn dependency:analyze`.

Before the first commit in this PR, running `mvn dependency:analyze` resulted in the following warnings:
```sh
[WARNING] Used undeclared dependencies found:
[WARNING]    org.slf4j:slf4j-api:jar:1.7.25:compile
[WARNING]    org.apache.logging.log4j:log4j-api:jar:2.20.0:compile
[WARNING]    jakarta.xml.bind:jakarta.xml.bind-api:jar:4.0.0:compile
[WARNING]    com.beust:jcommander:jar:1.82:compile
[WARNING] Unused declared dependencies found:
[WARNING]    junit:junit:jar:4.13.2:test
```
With its changes, the situation has improved, and only the following warning remains:
```sh
[WARNING] Used undeclared dependencies found:
[WARNING]    org.slf4j:slf4j-api:jar:1.7.25:compile
```
which is not clear how to fix, because all my attempts to add this dependency have resulted in a warning that the dependency is `Unused declared ...`.

Perhaps the PR can be extended to fix the above issue.  Also, perhaps it can be extended with some test that checks that future changes in the code base do not result in new warnings.