### PR TITLE
Ensure all writes to oscoreCtxGenerated are synchronized

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/EdhocSessionPersistent.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/EdhocSessionPersistent.java
@@ -74,7 +74,7 @@ public class EdhocSessionPersistent extends EdhocSession {
         reset();
     }
 
-    public void resetIfEnabled() {
+    public synchronized void resetIfEnabled() {
         if (sessionResetEnabled) {
             reset();
         } else {
@@ -83,7 +83,7 @@ public class EdhocSessionPersistent extends EdhocSession {
         }
     }
 
-    public void reset() {
+    public synchronized void reset() {
         // own info with first supported cipher suite
         int selectedCipherSuite = getSupportedCipherSuites().get(0);
         setSelectedCipherSuite(selectedCipherSuite);


### PR DESCRIPTION
This file contained two methods with assignments to the above-named field which were synchronized and two other methods which were not. This is a bad code smell (if not a concurrency error).