### PR TITLE
Remove null pointer exception catch

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/CombinedMessageVersionConverter.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/CombinedMessageVersionConverter.java
@@ -9,10 +9,14 @@ import java.util.Arrays;
 public class CombinedMessageVersionConverter implements IStringConverter<CombinedMessageVersion> {
     @Override
     public CombinedMessageVersion convert(String value) {
+        if (value == null) {
+            throw new ParameterException("Provided null Combined Message version value");
+        }
+
         try {
             String resolvedValue = PropertyResolver.resolve(value);
             return CombinedMessageVersion.valueOf(resolvedValue);
-        } catch (IllegalArgumentException | NullPointerException e) {
+        } catch (IllegalArgumentException e) {
             throw new ParameterException("Combined Message version " + value
                 + " is not supported. Available versions are: "
                 + Arrays.toString(CombinedMessageVersion.values()));

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/ProtocolVersionConverter.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/ProtocolVersionConverter.java
@@ -9,10 +9,14 @@ import java.util.Arrays;
 public class ProtocolVersionConverter implements IStringConverter<ProtocolVersion> {
     @Override
     public ProtocolVersion convert(String value) {
+        if (value == null) {
+            throw new ParameterException("Provided null Protocol version value");
+        }
+
         try {
             String resolvedValue = PropertyResolver.resolve(value);
             return ProtocolVersion.valueOf(resolvedValue);
-        } catch (IllegalArgumentException | NullPointerException e) {
+        } catch (IllegalArgumentException e) {
             throw new ParameterException("Protocol version " + value
                 + " is not supported. Available versions are: "
                 + Arrays.toString(ProtocolVersion.values()));


### PR DESCRIPTION
Some library calls throw a `NullPointerException` if their input parameter is `null`. That is why these exceptions were caught inside a `try-catch` statement. However, catching a `NullPointerException` is not a good practice, so I tried to prevent it from being thrown by adding some additional checks.

One stricter option is to wrap the library calls with an `if statement`, but I do not think that is necessary something like:
```java
if (param != null) {
    funcThrowingNullPointerExc(param);
}
```

Essentially the additional checks along with the surrounding code *ensure* the non-null invariant.