### PR TITLE
Two fixes to ManyFilesAuthenticator.java

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/ManyFilesAuthenticator.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/ManyFilesAuthenticator.java
@@ -467,10 +467,11 @@ public class ManyFilesAuthenticator implements Authenticator {
             } else {
                 switch (credType) {
                     case Constants.CRED_TYPE_CCS ->
-                            addAllPeerIdCredForCCSCred(cred, peerPublicKey, kid);
+                        addAllPeerIdCredForCCSCred(cred, peerPublicKey, kid);
                     case Constants.CRED_TYPE_X509 ->
-                            addAllPeerIdCredForX509Cred(cred, peerPublicKey, serializedCert, x5uLink);
-                    default -> throw new IllegalStateException("Unexpected credType value: " + credType);
+                        addAllPeerIdCredForX509Cred(cred, peerPublicKey, serializedCert, x5uLink);
+                    default ->
+                        throw new IllegalStateException("Unexpected credType value: " + credType);
                 }
             }
         }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/ManyFilesAuthenticator.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/ManyFilesAuthenticator.java
@@ -45,7 +45,7 @@ public class ManyFilesAuthenticator implements Authenticator {
     protected List<Integer> supportedCipherSuites;
 
     // cache read DER files, so as not to read them after each constructor call
-    protected static final HashMap<String, byte[]> sharedDerFilesMap = new HashMap<>();
+    static final HashMap<String, byte[]> sharedDerFilesMap = new HashMap<>();  // package-private
 
     protected ManyFilesAuthenticationConfig manyFilesAuthenticationConfig;
 
@@ -470,6 +470,7 @@ public class ManyFilesAuthenticator implements Authenticator {
                             addAllPeerIdCredForCCSCred(cred, peerPublicKey, kid);
                     case Constants.CRED_TYPE_X509 ->
                             addAllPeerIdCredForX509Cred(cred, peerPublicKey, serializedCert, x5uLink);
+                    default -> throw new IllegalStateException("Unexpected credType value: " + credType);
                 }
             }
         }


### PR DESCRIPTION
1. Make a field package-private rather than protected
2. Add a missing default case to a switch (is it the correct exception to throw?)