### PR TITLE
Slightly more informative run description

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/KeyConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/KeyConfig.java
@@ -3,6 +3,7 @@ package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config.auth
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.statistics.RunDescriptionPrinter;
 
 import java.io.PrintWriter;
+import java.util.Arrays;
 
 public interface KeyConfig extends RunDescriptionPrinter {
     public String getMapPrivateFilename();
@@ -27,11 +28,11 @@ public interface KeyConfig extends RunDescriptionPrinter {
     default void printRunDescriptionSelf(PrintWriter printWriter) {
         printWriter.println("Map Private Filename: " + getMapPrivateFilename());
         printWriter.println("Map Public Filename: " + getMapPublicFilename());
-        printWriter.println("Map Kid: " + getMapKid());
+        printWriter.println("Map Kid: " + Arrays.toString(getMapKid()));
         printWriter.println("Map X509 Filename: " + getMapX509Filename());
         printWriter.println("Map X5u Link: " + getMapX5uLink());
         printWriter.println("Sul Public Filename: " + getSulPublicFilename());
-        printWriter.println("Sul Kid: " + getSulKid());
+        printWriter.println("Sul Kid: " + Arrays.toString(getSulKid()));
         printWriter.println("Sul X509 Filename: " + getSulX509Filename());
         printWriter.println("Sul X5u Link: " + getSulX5uLink());
     }


### PR DESCRIPTION
Calling `toString()` on a byte array does not provide much information. Call `Arrays.toString()` instead.