### PR TITLE
Prefer `Thread.sleep()` over `wait()`

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/EdhocSessionPersistent.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/EdhocSessionPersistent.java
@@ -13,6 +13,7 @@ import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.oscore.OSCoreCtx;
 import org.eclipse.californium.oscore.OSException;
 
+import java.lang.Thread;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -187,7 +188,7 @@ public class EdhocSessionPersistent extends EdhocSession {
         LOGGER.debug("Start of waitForOscoreContext");
         if (!oscoreCtxGenerated) {
             try {
-                wait(timeoutMillis);
+                Thread.sleep(timeoutMillis);
             } catch (InterruptedException e) {
                 LOGGER.warn("Wait for OSCORE context generation interrupted: {}", e.getMessage());
             }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/EdhocSessionPersistent.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/EdhocSessionPersistent.java
@@ -13,7 +13,6 @@ import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.oscore.OSCoreCtx;
 import org.eclipse.californium.oscore.OSException;
 
-import java.lang.Thread;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;


### PR DESCRIPTION
So as to avoid problems with spurious wakeups.
However, we need to find some solution to the issue with calling `Thread.sleep()` while holding a lock (due to being in a`synchronized` method).