### PR TITLE
Avoid surprising behaviour of string.split(String)

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/EdhocMapperConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/EdhocMapperConfig.java
@@ -179,7 +179,7 @@ public class EdhocMapperConfig extends MapperConfigStandard {
     }
 
     protected String checkAndReturnHost(String host) {
-        String[] hostArray = host.split(":");
+        String[] hostArray = host.split(":", -1);
 
         if (hostArray.length != 2) {
             throw new RuntimeException("Argument provided to -connect has not the correct format: ip:port");

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/connectors/EdhocServer.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/connectors/EdhocServer.java
@@ -34,7 +34,7 @@ public class EdhocServer extends CoapServer {
     }
 
     protected String extractLeafResourceString(String resource) {
-        String[] resources = resource.split("/");
+        String[] resources = resource.split("/", -1);
         return resources[resources.length - 1];
     }
 
@@ -50,7 +50,7 @@ public class EdhocServer extends CoapServer {
     protected CoapResource createInnerResourceTree(String resource) {
         // resources list includes names of:
         // root resource, inner resources and leaf resource
-        String[] resources = resource.split("/");
+        String[] resources = resource.split("/", -1);
 
         if (resources.length <= 1) {
             // only leaf resource name is present

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/connectors/ServerMapperConnector.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/connectors/ServerMapperConnector.java
@@ -36,7 +36,7 @@ public class ServerMapperConnector implements EdhocMapperConnector {
         this.appResource = appResource;
         this.timeout = originalTimeout;
 
-        String[] hostAndPort = coapHost.replace("coap://", "").split(":");
+        String[] hostAndPort = coapHost.replace("coap://", "").split(":", -1);
         this.host = hostAndPort[0];
         this.port = Integer.parseInt(hostAndPort[1]);
     }


### PR DESCRIPTION
Set an explicit limit to `-1` to match the behaviour of `Splitter`.
More about the issues: https://errorprone.info/bugpattern/StringSplitter