### PR TITLE
Prefer using Map instead of HashMap

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/EdhocEndpointInfoPersistent.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/EdhocEndpointInfoPersistent.java
@@ -8,15 +8,16 @@ import org.eclipse.californium.oscore.HashMapCtxDB;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class EdhocEndpointInfoPersistent extends EdhocEndpointInfo {
-    protected HashMap<CBORObject, EdhocSessionPersistent> edhocSessionsPersistent;
+    protected Map<CBORObject, EdhocSessionPersistent> edhocSessionsPersistent;
 
     public EdhocEndpointInfoPersistent(
             HashMap<Integer, HashMap<Integer, CBORObject>> idCreds, HashMap<Integer, HashMap<Integer, CBORObject>> creds,
             HashMap<Integer, HashMap<Integer, OneKey>> keyPairs, HashMap<CBORObject, OneKey> peerPublicKeys,
-            HashMap<CBORObject, CBORObject> peerCredentials, HashMap<CBORObject, EdhocSessionPersistent> edhocSessionsPersistent,
+            HashMap<CBORObject, CBORObject> peerCredentials, Map<CBORObject, EdhocSessionPersistent> edhocSessionsPersistent,
             Set<CBORObject> usedConnectionIds, List<Integer> supportedCipherSuites, Set<Integer> supportedEADs,
             HashMap<Integer, List<CBORObject>> eadProductionInput, int trustModel, HashMapCtxDB db, String oscoreUri,
             int OSCORE_REPLAY_WINDOW, int MAX_UNFRAGMENTED_SIZE, HashMap<String, AppProfile> appProfiles) {
@@ -28,7 +29,7 @@ public class EdhocEndpointInfoPersistent extends EdhocEndpointInfo {
         this.edhocSessionsPersistent = edhocSessionsPersistent;
     }
 
-    public HashMap<CBORObject, EdhocSessionPersistent> getEdhocSessionsPersistent() {
+    public Map<CBORObject, EdhocSessionPersistent> getEdhocSessionsPersistent() {
         return edhocSessionsPersistent;
     }
 

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/EdhocLayerPersistent.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/EdhocLayerPersistent.java
@@ -23,8 +23,8 @@ import org.eclipse.californium.oscore.OSException;
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /** Adapted from {@link org.eclipse.californium.edhoc.EdhocLayer} */
 public class EdhocLayerPersistent extends AbstractLayer {
@@ -33,8 +33,8 @@ public class EdhocLayerPersistent extends AbstractLayer {
     // The OSCORE context database
     OSCoreCtxDB ctxDb;
 
-     // Map of existing EDHOC sessions
-    HashMap<CBORObject, EdhocSessionPersistent> edhocSessionsPersistent;
+    // Map of existing EDHOC sessions
+    Map<CBORObject, EdhocSessionPersistent> edhocSessionsPersistent;
 
     // MessageProcessor for reading message 3
     MessageProcessorPersistent messageProcessorPersistent;

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/MessageProcessorPersistent.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/MessageProcessorPersistent.java
@@ -252,7 +252,7 @@ public class MessageProcessorPersistent {
     /** Adapted from {@link org.eclipse.californium.edhoc.MessageProcessor#readMessage2} */
     public boolean readMessage2(byte[] sequence) {
         LOGGER.debug("Start of readMessage2");
-        HashMap<CBORObject, EdhocSessionPersistent> edhocSessions = edhocMapperState.getEdhocEndpointInfoPersistent().getEdhocSessionsPersistent();
+        Map<CBORObject, EdhocSessionPersistent> edhocSessions = edhocMapperState.getEdhocEndpointInfoPersistent().getEdhocSessionsPersistent();
         HashMap<CBORObject, OneKey> peerPublicKeys = edhocMapperState.getEdhocEndpointInfoPersistent().getPeerPublicKeys();
         HashMap<CBORObject, CBORObject> peerCredentials = edhocMapperState.getEdhocEndpointInfoPersistent().getPeerCredentials();
         Set<CBORObject> usedConnectionIds = edhocMapperState.getEdhocEndpointInfoPersistent().getUsedConnectionIds();
@@ -907,7 +907,7 @@ public class MessageProcessorPersistent {
     /** Adapted from {@link org.eclipse.californium.edhoc.MessageProcessor#readMessage4} */
     public boolean readMessage4(byte[] sequence) {
         LOGGER.debug("Start of readMessage4");
-        HashMap<CBORObject, EdhocSessionPersistent> edhocSessions = edhocMapperState.getEdhocEndpointInfoPersistent().getEdhocSessionsPersistent();
+        Map<CBORObject, EdhocSessionPersistent> edhocSessions = edhocMapperState.getEdhocEndpointInfoPersistent().getEdhocSessionsPersistent();
         Set<CBORObject> usedConnectionIds = edhocMapperState.getEdhocEndpointInfoPersistent().getUsedConnectionIds();
 
         if (sequence == null || edhocSessions == null || usedConnectionIds == null) {
@@ -1601,7 +1601,7 @@ public class MessageProcessorPersistent {
     /** Adapted from {@link org.eclipse.californium.edhoc.MessageProcessor#readMessage3} */
     public boolean readMessage3(byte[] sequence) {
         LOGGER.debug("Start of readMessage3");
-        HashMap<CBORObject, EdhocSessionPersistent> edhocSessions = edhocMapperState.getEdhocEndpointInfoPersistent().getEdhocSessionsPersistent();
+        Map<CBORObject, EdhocSessionPersistent> edhocSessions = edhocMapperState.getEdhocEndpointInfoPersistent().getEdhocSessionsPersistent();
         HashMap<CBORObject, OneKey> peerPublicKeys = edhocMapperState.getEdhocEndpointInfoPersistent().getPeerPublicKeys();
         HashMap<CBORObject, CBORObject> peerCredentials = edhocMapperState.getEdhocEndpointInfoPersistent().getPeerCredentials();
         Set<CBORObject> usedConnectionIds = edhocMapperState.getEdhocEndpointInfoPersistent().getUsedConnectionIds();
@@ -2138,7 +2138,7 @@ public class MessageProcessorPersistent {
     /** Adapted from {@link org.eclipse.californium.edhoc.MessageProcessor#readErrorMessage} */
     public boolean readErrorMessage(byte[] sequence) {
         LOGGER.debug("Start of readErrorMessage");
-        HashMap<CBORObject, EdhocSessionPersistent> edhocSessions = edhocMapperState.getEdhocEndpointInfoPersistent()
+        Map<CBORObject, EdhocSessionPersistent> edhocSessions = edhocMapperState.getEdhocEndpointInfoPersistent()
                 .getEdhocSessionsPersistent();
 
         if (sequence == null || edhocSessions == null) {

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/MessageProcessorPersistent.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/MessageProcessorPersistent.java
@@ -253,8 +253,8 @@ public class MessageProcessorPersistent {
     public boolean readMessage2(byte[] sequence) {
         LOGGER.debug("Start of readMessage2");
         Map<CBORObject, EdhocSessionPersistent> edhocSessions = edhocMapperState.getEdhocEndpointInfoPersistent().getEdhocSessionsPersistent();
-        HashMap<CBORObject, OneKey> peerPublicKeys = edhocMapperState.getEdhocEndpointInfoPersistent().getPeerPublicKeys();
-        HashMap<CBORObject, CBORObject> peerCredentials = edhocMapperState.getEdhocEndpointInfoPersistent().getPeerCredentials();
+        Map<CBORObject, OneKey> peerPublicKeys = edhocMapperState.getEdhocEndpointInfoPersistent().getPeerPublicKeys();
+        Map<CBORObject, CBORObject> peerCredentials = edhocMapperState.getEdhocEndpointInfoPersistent().getPeerCredentials();
         Set<CBORObject> usedConnectionIds = edhocMapperState.getEdhocEndpointInfoPersistent().getUsedConnectionIds();
         Set<CBORObject> ownIdCreds = edhocMapperState.getOwnIdCreds();
 
@@ -1602,8 +1602,8 @@ public class MessageProcessorPersistent {
     public boolean readMessage3(byte[] sequence) {
         LOGGER.debug("Start of readMessage3");
         Map<CBORObject, EdhocSessionPersistent> edhocSessions = edhocMapperState.getEdhocEndpointInfoPersistent().getEdhocSessionsPersistent();
-        HashMap<CBORObject, OneKey> peerPublicKeys = edhocMapperState.getEdhocEndpointInfoPersistent().getPeerPublicKeys();
-        HashMap<CBORObject, CBORObject> peerCredentials = edhocMapperState.getEdhocEndpointInfoPersistent().getPeerCredentials();
+        Map<CBORObject, OneKey> peerPublicKeys = edhocMapperState.getEdhocEndpointInfoPersistent().getPeerPublicKeys();
+        Map<CBORObject, CBORObject> peerCredentials = edhocMapperState.getEdhocEndpointInfoPersistent().getPeerCredentials();
         Set<CBORObject> usedConnectionIds = edhocMapperState.getEdhocEndpointInfoPersistent().getUsedConnectionIds();
 
         if (sequence == null || edhocSessions == null || peerPublicKeys == null || peerCredentials == null

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/ManyFilesAuthenticator.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/ManyFilesAuthenticator.java
@@ -34,18 +34,18 @@ public class ManyFilesAuthenticator implements Authenticator {
     protected int authenticationMethod;
     protected int ownCredType;
     protected int ownIdCredType;
-    protected HashMap<Integer, HashMap<Integer, OneKey>> keyPairs;
-    protected HashMap<Integer, HashMap<Integer, CBORObject>> idCreds;
-    protected HashMap<Integer, HashMap<Integer, CBORObject>> creds;
+    protected Map<Integer, HashMap<Integer, OneKey>> keyPairs;
+    protected Map<Integer, HashMap<Integer, CBORObject>> idCreds;
+    protected Map<Integer, HashMap<Integer, CBORObject>> creds;
     protected Set<CBORObject> ownIdCreds;
     protected int peerCredType;
     protected int peerIdCredType;
-    protected HashMap<CBORObject, OneKey> peerPublicKeys;
-    protected HashMap<CBORObject, CBORObject> peerCredentials;
+    protected Map<CBORObject, OneKey> peerPublicKeys;
+    protected Map<CBORObject, CBORObject> peerCredentials;
     protected List<Integer> supportedCipherSuites;
 
     // cache read DER files, so as not to read them after each constructor call
-    static final HashMap<String, byte[]> sharedDerFilesMap = new HashMap<>();  // package-private
+    static final Map<String, byte[]> sharedDerFilesMap = new HashMap<>();
 
     protected ManyFilesAuthenticationConfig manyFilesAuthenticationConfig;
 

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/TestVectorAuthenticator.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/TestVectorAuthenticator.java
@@ -12,17 +12,18 @@ import org.eclipse.californium.elements.util.StringUtil;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
 public class TestVectorAuthenticator implements Authenticator {
 
-    protected HashMap<Integer, HashMap<Integer, OneKey>> keyPairs;
-    protected HashMap<Integer, HashMap<Integer, CBORObject>> idCreds;
-    protected HashMap<Integer, HashMap<Integer, CBORObject>> creds;
+    protected Map<Integer, HashMap<Integer, OneKey>> keyPairs;
+    protected Map<Integer, HashMap<Integer, CBORObject>> idCreds;
+    protected Map<Integer, HashMap<Integer, CBORObject>> creds;
     protected Set<CBORObject> ownIdCreds;
-    protected HashMap<CBORObject, OneKey> peerPublicKeys;
-    protected HashMap<CBORObject, CBORObject> peerCredentials;
+    protected Map<CBORObject, OneKey> peerPublicKeys;
+    protected Map<CBORObject, CBORObject> peerCredentials;
     protected List<Integer> supportedCipherSuites;
 
     protected TestVectorAuthenticationConfig testVectorAuthenticationConfig;


### PR DESCRIPTION
Substitute some occurrences of `HashMap` with the more general `Map`. Due to direct calls to the mapper which is currently used (the [edhoc branch](https://github.com/rikard-sics/californium/tree/edhoc) of RISE's fork of Califormium) some other occurrences of `HashMap` cannot be substituted so easily.