### PR TITLE
Update connection id generation and EDHOC-RS commit

### DIFF
--- a/scripts/setup_sul.sh
+++ b/scripts/setup_sul.sh
@@ -14,7 +14,7 @@ mkdir -p "${SOURCES_DIR}" "${SERVERS_DIR}" "${CLIENTS_DIR}"
 
 setup_edhoc_rs() {
   # edhoc-rs
-  readonly COMMIT_HASH="c40bd2d19561ec985dbcd1ee94cc3c41047cac3f"
+  readonly COMMIT_HASH="337c47ca684b60f5dbf09828ec7705afac0e79f4"
 
   set -e
   echo "Setting up EDHOC-Rust in ${SOURCES_DIR}"

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/MessageProcessorPersistent.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/MessageProcessorPersistent.java
@@ -1316,8 +1316,11 @@ public class MessageProcessorPersistent {
             return true;
         }
 
-        byte[] connectionIdResponder = Util.getConnectionId(endpointInfo.getUsedConnectionIds(),
+        byte[] connectionIdResponder = oldSession.getConnectionId();
+        if (edhocMapperState.getEdhocMapperConfig().generateOwnConnectionId()) {
+            connectionIdResponder = Util.getConnectionId(endpointInfo.getUsedConnectionIds(),
                 endpointInfo.getOscoreDb(), connectionIdInitiator);
+        }
 
         EdhocSessionPersistent newSession = new EdhocSessionPersistent(oldSession.getSessionUri(),
                 oldSession.isInitiator(), oldSession.isClientInitiated(), method, connectionIdResponder, endpointInfo,

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/EdhocMapperConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/EdhocMapperConfig.java
@@ -75,9 +75,15 @@ public class EdhocMapperConfig extends MapperConfigStandard {
 
     @Parameter(names = "-ownConnectionId", description = "Use this id as own connection id for the EDHOC protocol. "
             + "Avoid an id that would coincide with a peer connection id found during EDHOC, in order for the OSCORE "
-            + "context to be derived successfully from those two ids. Available: empty byte string: [] or single-line "
-            + "hexadecimal byte string in the format: 0a0b0c0d0e0f")
+            + "context to be derived successfully from those two ids. If the mapper is a Responder and "
+            + "`disableOwnConnectionIdGeneration` is not specified, then the `ownConnectionId` is ignored. "
+            + "Available: empty byte string: [] or single-line hexadecimal byte string in the format: 0a0b0c0d0e0f.")
     protected String ownConnectionId = "36";
+
+    @Parameter(names = "-disableOwnConnectionIdGeneration", description = "It is used only when the mapper is a Responder. "
+            + "It disables the automatic generation of the mapper's connection id every time when an EDHOC Message 1 "
+            + "is received from the Initiator SUT. In that case the `ownConnectionId` is used every time.")
+    protected boolean disableOwnConnectionIdGeneration = false;
 
     @Parameter(names = "-forceOscoreSenderId", description = "Use this OSCORE sender id, instead of the peer "
             + "connection id that is found during EDHOC. Available: empty byte string: [] or single-line hexadecimal "
@@ -159,6 +165,10 @@ public class EdhocMapperConfig extends MapperConfigStandard {
         return parseHexString(ownConnectionId);
     }
 
+    public boolean generateOwnConnectionId() {
+        return !disableOwnConnectionIdGeneration;
+    }
+
     public byte[] getForceOscoreSenderId() {
         return parseHexString(forceOscoreSenderId);
     }
@@ -234,6 +244,7 @@ public class EdhocMapperConfig extends MapperConfigStandard {
         printWriter.println("use Session Reset: " + useSessionReset());
         printWriter.println("use CX Correlation: " + useCXCorrelation());
         printWriter.println("Own Connection Id: " + this.ownConnectionId);
+        printWriter.println("Generate Own Connection Id: " + generateOwnConnectionId());
         printWriter.println("Force Oscore Sender Id: " + this.forceOscoreSenderId);
         printWriter.println("Force Oscore Recipient Id: " + this.forceOscoreRecipientId);
     }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/EdhocMapperState.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/EdhocMapperState.java
@@ -153,6 +153,11 @@ public abstract class EdhocMapperState implements State {
         authenticator.setupPeerAuthenticationCredentials();
 
         // Prepare new session
+
+        // add empty connection id to used ones so as not to be used
+        // in case a new connection id is generated automatically
+        usedConnectionIds.add(CBORObject.FromObject(new byte[0]));
+
         byte[] connectionId = edhocMapperConfig.getOwnConnectionId();
         usedConnectionIds.add(CBORObject.FromObject(connectionId));
 


### PR DESCRIPTION
I updated the commit hash of *EDHOC-RS*, in order to build correctly again. This made me discover an incompatibility between the automatically generated connection identifier of the Responder and the new, stricter parsing of  *EDHOC-RS*. 

When *EDHOC-Fuzzer* is the Responder, after reading *EDHOC Message 1*, tries to generate a new connection identifier for its new session. The responsible `Util.getConnectionId` method returned (deterministically) an empty connection identifier (0 element byte array) before, because it was available as an id. However, that led the corresponding `C_R` to be incompatible with the *EDHOC-RS* client.

These changes make the `Util.getConnectionId` avoid the generation of an empty connection id and also are extended to allow the users to disable the automatic generation of a connection id (which happens only when the *EDHOC-Fuzzer* is a Responder). 'Disabling' means that the fixed `ownConnectionId` will be used, instead of generating a new one after reading *EDHOC Message 1*.