### PR TITLE
Update cf-edhoc and protocol-state-fuzzer

### DIFF
--- a/scripts/cf-edhoc.patch
+++ b/scripts/cf-edhoc.patch
@@ -1,8 +1,8 @@
 diff --git a/bom/pom.xml b/bom/pom.xml
-index 9a37b944c..a73e3406e 100644
+index 15e2b4810..d79b11316 100644
 --- a/bom/pom.xml
 +++ b/bom/pom.xml
-@@ -123,7 +123,7 @@
+@@ -129,7 +129,7 @@
  				<groupId>net.i2p.crypto</groupId>
  				<artifactId>eddsa</artifactId>
  				<version>${eddsa.version}</version>
@@ -12,10 +12,10 @@ index 9a37b944c..a73e3406e 100644
  
  			<dependency>
 diff --git a/californium-core/src/main/java/org/eclipse/californium/core/config/CoapConfig.java b/californium-core/src/main/java/org/eclipse/californium/core/config/CoapConfig.java
-index b04065b31..f319344a3 100644
+index 1ac6465fc..cb6c25e0b 100644
 --- a/californium-core/src/main/java/org/eclipse/californium/core/config/CoapConfig.java
 +++ b/californium-core/src/main/java/org/eclipse/californium/core/config/CoapConfig.java
-@@ -358,7 +358,7 @@ public final class CoapConfig {
+@@ -387,7 +387,7 @@ public final class CoapConfig {
  	 * target="_blank">RFC7252, 4.8. Transmission Parameters</a>.
  	 */
  	public static final IntegerDefinition MAX_RETRANSMIT = new IntegerDefinition(MODULE + "MAX_RETRANSMIT",
@@ -24,14 +24,6 @@ index b04065b31..f319344a3 100644
  	/**
  	 * The EXCHANGE_LIFETIME for CON requests. See
  	 * <a href="https://datatracker.ietf.org/doc/html/rfc7252#section-4.8.2"
-@@ -691,6 +691,7 @@ public final class CoapConfig {
- 			config.set(COAP_SECURE_PORT, CoAP.DEFAULT_COAP_SECURE_PORT);
- 
- 			config.set(ACK_TIMEOUT, 2000, TimeUnit.MILLISECONDS);
-+			config.set(MAX_ACK_TIMEOUT, 60000, TimeUnit.MILLISECONDS);
- 			config.set(ACK_INIT_RANDOM, 1.5f);
- 			config.set(ACK_TIMEOUT_SCALE, 2f);
- 			config.set(MAX_RETRANSMIT, 4);
 diff --git a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayerParameters.java b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayerParameters.java
 index 41d06c9cc..9bd3d912b 100644
 --- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayerParameters.java
@@ -48,7 +40,7 @@ index 41d06c9cc..9bd3d912b 100644
  			if (1 > nstart) {
  				throw new IllegalStateException("Nstart " + nstart + " must not be less than 1!");
 diff --git a/cf-edhoc/pom.xml b/cf-edhoc/pom.xml
-index 8847ec87f..cc45e3998 100644
+index 5dd9cc4ac..02b2bf46c 100644
 --- a/cf-edhoc/pom.xml
 +++ b/cf-edhoc/pom.xml
 @@ -71,7 +71,8 @@
@@ -93,7 +85,7 @@ index 40a137656..b4d4c5114 100644
  		final String digest = "SHA256"; // Hash to use
  
 diff --git a/cf-edhoc/src/main/java/org/eclipse/californium/edhoc/SharedSecretCalculation.java b/cf-edhoc/src/main/java/org/eclipse/californium/edhoc/SharedSecretCalculation.java
-index 8872b04d7..715bf49aa 100644
+index 78fc7c2f2..4ae366605 100644
 --- a/cf-edhoc/src/main/java/org/eclipse/californium/edhoc/SharedSecretCalculation.java
 +++ b/cf-edhoc/src/main/java/org/eclipse/californium/edhoc/SharedSecretCalculation.java
 @@ -286,7 +286,7 @@ public class SharedSecretCalculation {
@@ -204,7 +196,7 @@ index 8872b04d7..715bf49aa 100644
  
  		if (privateKey == null || publicKey == null) {
  			System.err.println("Public key and/or private key not found.");
-@@ -835,7 +835,7 @@ public class SharedSecretCalculation {
+@@ -847,7 +847,7 @@ public class SharedSecretCalculation {
  	 * 
  	 * @throws CoseException
  	 */
@@ -227,10 +219,10 @@ index 1e6e8a3fd..e305a8749 100644
          return claimSetMap.EncodeToBytes();
  		
 diff --git a/cf-oscore/pom.xml b/cf-oscore/pom.xml
-index d1abd4e7d..7c8701b3a 100644
+index f730afadd..9416f1244 100644
 --- a/cf-oscore/pom.xml
 +++ b/cf-oscore/pom.xml
-@@ -38,7 +38,8 @@
+@@ -41,7 +41,8 @@
          	<dependency> <!-- Rikard: Added this dependency -->
  	            <groupId>net.i2p.crypto</groupId>
  	            <artifactId>eddsa</artifactId>

--- a/scripts/setup_fuzzer.sh
+++ b/scripts/setup_fuzzer.sh
@@ -8,7 +8,7 @@ readonly BASE_DIR
 setup_psf() {
     # setup protocol-state-fuzzer library
 
-    COMMIT_HASH="86da423ac2269f5d7b61503ae8b8c2f45a37f570"
+    COMMIT_HASH="4d7d6256d0be4cce240399b65ce9e486700b15bb"
 
     set -e
     cd "${BASE_DIR}"

--- a/scripts/setup_fuzzer.sh
+++ b/scripts/setup_fuzzer.sh
@@ -26,7 +26,7 @@ setup_cf_edhoc() {
     # setup cf-edhoc library
 
     PATCH_FILE="${SCRIPT_DIR}/cf-edhoc.patch"
-    COMMIT_HASH="d728368ac44dabceff2b4a2c5fcd757552e65f9e"
+    COMMIT_HASH="4cacfe37d5e213d03c0ab0a8dacaaeb156a704d2"
 
     set -e
     cd "${BASE_DIR}"
@@ -37,13 +37,15 @@ setup_cf_edhoc() {
     git apply "${PATCH_FILE}"
     mvn package -DskipTests -am -pl cf-edhoc
     JAR_FILE=$(ls ./cf-edhoc/target/cf-edhoc-*-SNAPSHOT.jar)
+    POM_FILE=$(ls ./pom.xml)
 
     mvn install:install-file \
         -Dfile="${JAR_FILE}" \
         -DgroupId=se.ri.org.eclipse.californium \
         -DartifactId=cf-edhoc \
         -Dversion=0.0.0 \
-        -Dpackaging=jar
+        -Dpackaging=jar \
+        -DpomFile="${POM_FILE}"
 
     cd "${BASE_DIR}"
     rm -rf ./californium/

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/EdhocLayerPersistent.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/EdhocLayerPersistent.java
@@ -8,7 +8,6 @@ import com.upokecenter.cbor.CBORObject;
 import com.upokecenter.cbor.CBORType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.MessageObserverAdapter;
@@ -400,7 +399,7 @@ public class EdhocLayerPersistent extends AbstractLayer {
         CoapExchangeInfo coapExchangeInfo = new CoapExchangeInfo(MID);
         coapExchangeInfo.setHasUnsuccessfulMessage(true);
 
-        coapExchangeInfo.setCoapExchange(new CoapExchange(exchange, new CoapResource("temporary")));
+        coapExchangeInfo.setCoapExchange(new CoapExchange(exchange));
         if (!edhocSessionPersistent.getCoapExchanger().getReceivedQueue().offer(coapExchangeInfo)) {
             LOGGER.warn("Full received queue found");
         }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/connectors/EdhocServer.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/connectors/EdhocServer.java
@@ -11,6 +11,7 @@ import org.eclipse.californium.core.server.resources.CoapExchange;
 import java.net.InetSocketAddress;
 
 public class EdhocServer extends CoapServer {
+    private static final Logger LOGGER = LogManager.getLogger();
 
     public EdhocServer(String host, int port, String edhocResource, String appResource,
                        EdhocStackFactoryPersistent edhocStackFactoryPersistent,

--- a/src/main/resources/default_mapper_connection.config
+++ b/src/main/resources/default_mapper_connection.config
@@ -7,16 +7,16 @@ COAP.ACK_INIT_RANDOM=1.5
 # Default: 2[s]
 # Adjust MAX_ACK_TIMEOUT to add more time
 COAP.ACK_TIMEOUT=10[s]
-# Maximum CoAP acknowledge timeout for CON messages.
-# Default: 6[s]
-# Should be: ACK_TIMEOUT <= MAX_ACK_TIMEOUT
-COAP.MAX_ACK_TIMEOUT=10[s]
 # Scale factor for CoAP acknowledge backoff-timeout.
 # Default: 2.0
 COAP.ACK_TIMEOUT_SCALE=2.0
 # Enable automatic failover on "entity too large" response.
 # Default: true
 COAP.BLOCKWISE_ENTITY_TOO_LARGE_AUTO_FAILOVER=true
+# Reuse token for blockwise requests. Ease traceability but may introduce
+# vulnerability.
+# Default: false
+COAP.BLOCKWISE_REUSE_TOKEN=false
 # Interval to validate lifetime of blockwise status.
 # Default: 5[s]
 COAP.BLOCKWISE_STATUS_INTERVAL=5[s]
@@ -55,6 +55,10 @@ COAP.LEISURE=5[s]
 # Mark and sweep interval.
 # Default: 10[s]
 COAP.MARK_AND_SWEEP_INTERVAL=10[s]
+# Maximum CoAP acknowledge timeout.
+# Default: 1[min]
+# Should be: ACK_TIMEOUT <= MAX_ACK_TIMEOUT
+COAP.MAX_ACK_TIMEOUT=10[s]
 # Maximum number of active peers.
 # Default: 150000
 COAP.MAX_ACTIVE_PEERS=150000
@@ -75,6 +79,9 @@ COAP.MAX_RESOURCE_BODY_SIZE=8192
 # Default: 4
 # Should be >= 0 (0: no retransmissions)
 COAP.MAX_RETRANSMIT=0
+# Maximum number of observes on server-side. 0 to disable this limitation.
+# Default: 50000
+COAP.MAX_SERVER_OBSERVES=50000
 # Maximum server response delay.
 # Default: 250[s]
 COAP.MAX_SERVER_RESPONSE_DELAY=250[s]
@@ -125,6 +132,10 @@ COAP.PROTOCOL_STAGE_THREAD_COUNT=1
 # [STRICT, RELAXED, PRINCIPAL, PRINCIPAL_IDENTITY].
 # Default: STRICT
 COAP.RESPONSE_MATCHING=STRICT
+# Process empty messages strictly according RFC7252, 4.1 as format error.
+# Disable to ignore additional data as tokens or options.
+# Default: true
+COAP.STRICT_EMPTY_MESSAGE_FORMAT=false
 # Number of block per TCP-blockwise bulk transfer.
 # Default: 1
 COAP.TCP_NUMBER_OF_BULK_BLOCKS=1
@@ -137,3 +148,6 @@ COAP.USE_MESSAGE_OFFLOADING=false
 # Use initially a random value for MID.
 # Default: true
 COAP.USE_RANDOM_MID_START=true
+# Health status interval. 0 to disable the health status.
+# Default: 0[ms]
+SYS.HEALTH_STATUS_INTERVAL=0[ms]


### PR DESCRIPTION
They made a quite large rebase in the `cf-edhoc` library, in order to use the latest californium version. Thus I thought it was time to update our dependency. This update involves:

* Update of the `cf-edhoc` commit hash, the way it is being set up and the patch
* Source code changes stemming from deprecated api usage, in order to resolve warnings (treated as errors) during compilation
* Update of the *protocol-state-fuzzer* commit hash, in order to use the `glassfish` runtime, because some class definitions were missing (So actually the glassfish dependency change occurred from here)
* Update of the `default_mapper_connection.config`, which is the latest Californium3 properties file. Other than addition and rearrangement of some properties, the important one is `COAP.STRICT_EMPTY_MESSAGE_FORMAT=false`.

#### Problem description

The problem was identified on the `sifis-home server_phase_1` test. 

Given the input of a `COAP_APP_MESSAGE` the server returned an `RST` message. Because of the default `true` value of the property `COAP.STRICT_EMPTY_MESSAGE_FORMAT`, this `RST` response was parsed as a format error and was not propagated to the upper layers making the *edhoc-fuzzer* believe it was a `TIMEOUT`. Making the value of the property `false` the response propagated to the *edhoc-fuzzer* and the output was identified as a `COAP_ERROR_MESSAGE`.