### PR TITLE
Advance cf-edhoc and rise commit

### DIFF
--- a/experiments/args/sifis-home/server_phase_1
+++ b/experiments/args/sifis-home/server_phase_1
@@ -22,6 +22,8 @@ v22
 -combinedMessageVersion
 v07
 
+-useOldContentFormat
+
 ## Mapper Auth ##
 
 -mapCredType

--- a/experiments/args/sifis-home/server_phase_2
+++ b/experiments/args/sifis-home/server_phase_2
@@ -22,6 +22,8 @@ v22
 -combinedMessageVersion
 v07
 
+-useOldContentFormat
+
 ## Mapper Auth ##
 
 -mapCredType

--- a/experiments/args/sifis-home/server_phase_3
+++ b/experiments/args/sifis-home/server_phase_3
@@ -22,6 +22,8 @@ v22
 -combinedMessageVersion
 v07
 
+-useOldContentFormat
+
 ## Mapper Auth ##
 
 -mapCredType

--- a/experiments/args/sifis-home/server_phase_4
+++ b/experiments/args/sifis-home/server_phase_4
@@ -22,6 +22,8 @@ v22
 -combinedMessageVersion
 v07
 
+-useOldContentFormat
+
 ## Mapper Auth ##
 
 -mapCredType

--- a/scripts/cf-edhoc.patch
+++ b/scripts/cf-edhoc.patch
@@ -160,39 +160,7 @@ index 78fc7c2f2..2ecc18748 100644
  
          // Attempt to recalculate Y value if missing
  		if (publicKeyY == null) {
-@@ -508,6 +508,31 @@ public class SharedSecretCalculation {
- 		return key;
- 	}
- 
-+	/**
-+	 * Takes a byte array and returns a new left zero-padded array of the
-+	 * specified length, if the input array is smaller than the specified length.
-+	 * Otherwise the original array is returned.
-+	 *
-+	 * @param base the original byte array
-+	 * @param length the desired length of the output
-+	 *
-+	 * @return a byte array of the specified length after adding leftmost zero-padding
-+	 *         or the original byte array
-+	 */
-+	public static byte[] padLeft(byte[] base, int length) {
-+		if (base.length >= length) {
-+			return base;
-+		}
-+
-+		int b_offset = 0;
-+		int r_offset = length - base.length;
-+		int r_length = base.length;
-+		byte[] result = new byte[length];
-+
-+		System.arraycopy(base, b_offset, result, r_offset, r_length);
-+		return result;
-+	}
-+
- 	/**
- 	 * Takes an ECDSA_256 X coordinate and computes a valid Y value for that X.
- 	 * Will only only return one of the possible Y values.
-@@ -530,7 +555,7 @@ public class SharedSecretCalculation {
+@@ -530,7 +530,7 @@ public class SharedSecretCalculation {
  	 * @return the recomputed Y value for that X
  	 * @throws CoseException if recomputation fails
  	 */
@@ -201,26 +169,6 @@ index 78fc7c2f2..2ecc18748 100644
  
  		BigInteger x = new BigInteger(1, publicKeyX);
  
-@@ -557,8 +582,8 @@ public class SharedSecretCalculation {
- 		// System.out.println("Root2: " +
- 		// StringUtil.byteArray2HexString(root2.toByteArray()));
- 
--		byte[] root1Bytes = root1.toByteArray();
--		byte[] root2Bytes = root2.toByteArray();
-+		byte[] root1Bytes = padLeft(root1.toByteArray(), 32);
-+		byte[] root2Bytes = padLeft(root2.toByteArray(), 32);
- 
- 		if (root1Bytes.length == 33) {
- 			root1Bytes = Arrays.copyOfRange(root1Bytes, 1, 33);
-@@ -567,7 +592,7 @@ public class SharedSecretCalculation {
- 			root2Bytes = Arrays.copyOfRange(root2Bytes, 1, 33);
- 		}
- 
--		byte[] xBytes = x.toByteArray();
-+		byte[] xBytes = padLeft(x.toByteArray(), 32);
- 		if (xBytes.length == 33) {
- 			xBytes = Arrays.copyOfRange(xBytes, 1, 33);
- 		}
 @@ -642,7 +667,7 @@ public class SharedSecretCalculation {
  	 * @return the recomputed Y value for that X
  	 * @throws CoseException if recomputation fails
@@ -230,26 +178,6 @@ index 78fc7c2f2..2ecc18748 100644
  
  		BigInteger x = new BigInteger(1, publicKeyX);
  
-@@ -667,8 +692,8 @@ public class SharedSecretCalculation {
- 		BigInteger root1 = squareMod(combined, prime);
- 		BigInteger root2 = root1.negate().mod(prime);
- 
--		byte[] root1Bytes = root1.toByteArray();
--		byte[] root2Bytes = root2.toByteArray();
-+		byte[] root1Bytes = padLeft(root1.toByteArray(), 48);
-+		byte[] root2Bytes = padLeft(root2.toByteArray(), 48);
- 
- 		if (root1Bytes.length == 49) {
- 			root1Bytes = Arrays.copyOfRange(root1Bytes, 1, 49);
-@@ -677,7 +702,7 @@ public class SharedSecretCalculation {
- 			root2Bytes = Arrays.copyOfRange(root2Bytes, 1, 49);
- 		}
- 
--		byte[] xBytes = x.toByteArray();
-+		byte[] xBytes = padLeft(x.toByteArray(), 48);
- 		if (xBytes.length == 49) {
- 			xBytes = Arrays.copyOfRange(xBytes, 1, 49);
- 		}
 @@ -752,7 +777,7 @@ public class SharedSecretCalculation {
       * @param val the value to square
       * @return one of the square roots

--- a/scripts/setup_fuzzer.sh
+++ b/scripts/setup_fuzzer.sh
@@ -26,7 +26,7 @@ setup_cf_edhoc() {
     # setup cf-edhoc library
 
     PATCH_FILE="${SCRIPT_DIR}/cf-edhoc.patch"
-    CHECKOUT="d9ed923deb4a4462aaf2bdc9fa3e3b369c8a43d2"
+    CHECKOUT="d96b10d00f2e5a6af9c9315e2f922d2360c8cb15"
 
     set -e
     cd "${BASE_DIR}"

--- a/scripts/setup_fuzzer.sh
+++ b/scripts/setup_fuzzer.sh
@@ -26,7 +26,7 @@ setup_cf_edhoc() {
     # setup cf-edhoc library
 
     PATCH_FILE="${SCRIPT_DIR}/cf-edhoc.patch"
-    CHECKOUT="9bdb7561147a36a2064c2f7968291436b742d2e9"
+    CHECKOUT="d9ed923deb4a4462aaf2bdc9fa3e3b369c8a43d2"
 
     set -e
     cd "${BASE_DIR}"

--- a/scripts/setup_sul.sh
+++ b/scripts/setup_sul.sh
@@ -35,7 +35,7 @@ setup_lakers() {
 
 setup_rise() {
   # rise
-  CHECKOUT="9bdb7561147a36a2064c2f7968291436b742d2e9"
+  CHECKOUT="d9ed923deb4a4462aaf2bdc9fa3e3b369c8a43d2"
   PREFIX="${SOURCES_DIR}/californium/cf-edhoc/src"
   POSTFIX="java/org/eclipse/californium/edhoc"
   CF_EDHOC_MAIN_DIR="${PREFIX}/main/${POSTFIX}"

--- a/scripts/setup_sul.sh
+++ b/scripts/setup_sul.sh
@@ -35,7 +35,7 @@ setup_lakers() {
 
 setup_rise() {
   # rise
-  CHECKOUT="d9ed923deb4a4462aaf2bdc9fa3e3b369c8a43d2"
+  CHECKOUT="d96b10d00f2e5a6af9c9315e2f922d2360c8cb15"
   PREFIX="${SOURCES_DIR}/californium/cf-edhoc/src"
   POSTFIX="java/org/eclipse/californium/edhoc"
   CF_EDHOC_MAIN_DIR="${PREFIX}/main/${POSTFIX}"

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/messages/EdhocProtocolMessage.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/messages/EdhocProtocolMessage.java
@@ -40,6 +40,7 @@ public abstract class EdhocProtocolMessage implements ProtocolMessage {
             contentFormat = Constants.APPLICATION_EDHOC_CBOR_SEQ;
         }
     }
+
     public byte[] getPayload() {
         return payload;
     }
@@ -48,7 +49,15 @@ public abstract class EdhocProtocolMessage implements ProtocolMessage {
         return messageCode;
     }
 
-    public int getContentFormat() {
+    public int getContentFormat(boolean oldVersion) {
+        if (oldVersion) {
+            return switch (contentFormat) {
+                case Constants.APPLICATION_EDHOC_CBOR_SEQ -> 65000;
+                case Constants.APPLICATION_CID_EDHOC_CBOR_SEQ -> 65001;
+                default -> contentFormat;
+            };
+        }
+
         return contentFormat;
     }
 

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/EdhocMapperConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/EdhocMapperConfig.java
@@ -64,6 +64,9 @@ public class EdhocMapperConfig extends MapperConfigStandard {
     @Parameter(names = "-disableContentFormat", description = "Do not add CoAP Content-Format in sending messages")
     protected boolean disableContentFormat = false;
 
+    @Parameter(names = "-useOldContentFormat", description = "Use the old CoAP Content-Format (6500x) in sending messages")
+    protected boolean useOldContentFormat = false;
+
     @Parameter(names = "-enableSessionReset", description = "Reset to default old session data, when Initiator mapper "
             + "sends a message to start a new session. Reset does not affect a Responder mapper")
     protected boolean enableSessionReset = false;
@@ -154,6 +157,10 @@ public class EdhocMapperConfig extends MapperConfigStandard {
 
     public boolean useContentFormat() {
         return !disableContentFormat;
+    }
+
+    public boolean useOldContentFormat() {
+        return useOldContentFormat;
     }
 
     public boolean useSessionReset() {
@@ -248,6 +255,7 @@ public class EdhocMapperConfig extends MapperConfigStandard {
         printWriter.println("App Message Payload To Coap Client: " + getAppMessagePayloadToCoapClient());
         printWriter.println("Coap Error As Edhoc Error: " + isCoapErrorAsEdhocError());
         printWriter.println("use Content Format: " + useContentFormat());
+        printWriter.println("use Old Content Format: " + useOldContentFormat());
         printWriter.println("use Session Reset: " + useSessionReset());
         printWriter.println("use CX Correlation: " + useCXCorrelation());
         printWriter.println("Own Connection Id: " + this.ownConnectionId);

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/AuthenticationConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/AuthenticationConfig.java
@@ -26,10 +26,9 @@ public class AuthenticationConfig implements RunDescriptionPrinter {
     protected IdCredType sulIdCredType = null;
 
     @Parameter(names = "-trustModel", description = "Trust Model for verifying authentication credentials of the SUL. "
-            + "Notes: STRICT means 'Trust and use only a stored and valid credential', "
-            + "LOFU means 'Trust and use a stored and valid credential or a valid credential with stored credential identifier', "
-            + "TOFU means 'Trust and use any (new) valid credential'.")
-    protected TrustModel trustModel = TrustModel.STRICT;
+            + "Notes: NO_LEARNING means 'Trust and use only a stored and valid credential', "
+            + "LEARNING means 'Trust and use any (new) valid credential'.")
+    protected TrustModel trustModel = TrustModel.NO_LEARNING;
 
     @ParametersDelegate
     protected ManyFilesAuthenticationConfig manyFilesAuthenticationConfig;
@@ -125,9 +124,8 @@ public class AuthenticationConfig implements RunDescriptionPrinter {
     }
 
     protected enum TrustModel {
-        STRICT(Constants.TRUST_MODEL_STRICT),
-        LOFU(Constants.TRUST_MODEL_LOFU),
-        TOFU(Constants.TRUST_MODEL_TOFU);
+        NO_LEARNING(Constants.TRUST_MODEL_NO_LEARNING),
+        LEARNING(Constants.TRUST_MODEL_LEARNING);
 
         private final Integer integer;
 

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/mappers/EdhocInputMapper.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/mappers/EdhocInputMapper.java
@@ -29,7 +29,9 @@ public class EdhocInputMapper extends InputMapper {
 
         // enable or disable content format
         EdhocMapperConfig edhocMapperConfig = (EdhocMapperConfig) mapperConfig;
-        int contentFormat = edhocMapperConfig.useContentFormat() ? edhocProtocolMessage.getContentFormat() : MediaTypeRegistry.UNDEFINED;
+        int contentFormat = edhocMapperConfig.useContentFormat() ?
+            edhocProtocolMessage.getContentFormat(edhocMapperConfig.useOldContentFormat()) :
+            MediaTypeRegistry.UNDEFINED;
 
         edhocMapperConnector.send(edhocProtocolMessage.getPayload(), edhocProtocolMessage.getPayloadType(),
                 edhocProtocolMessage.getMessageCode(), contentFormat);


### PR DESCRIPTION
This PR advances the commit of `cf-edhoc` library and `rise` sul.

The old content format identifiers needed to be introduced as a parameter, in order for the `sifis-home` server to work.

This server contains an older version of the `cf-edhoc` codebase, which relies on the old content format (65000 and 65001), which is why the tests were failing.