### PR TITLE
Upgrade Lakers to latest version (v0.7.2)

### DIFF
--- a/scripts/setup_sul.sh
+++ b/scripts/setup_sul.sh
@@ -14,7 +14,7 @@ mkdir -p "${SOURCES_DIR}" "${SERVERS_DIR}" "${CLIENTS_DIR}"
 
 setup_lakers() {
   # lakers
-  CHECKOUT="tags/v0.6.0"
+  CHECKOUT="tags/v0.6.2"
 
   set -e
   echo "Setting up Lakers in ${SOURCES_DIR}"

--- a/scripts/setup_sul.sh
+++ b/scripts/setup_sul.sh
@@ -14,7 +14,7 @@ mkdir -p "${SOURCES_DIR}" "${SERVERS_DIR}" "${CLIENTS_DIR}"
 
 setup_lakers() {
   # lakers
-  CHECKOUT="tags/v0.6.2"
+  CHECKOUT="tags/v0.7.2"
 
   set -e
   echo "Setting up Lakers in ${SOURCES_DIR}"

--- a/scripts/setup_sul.sh
+++ b/scripts/setup_sul.sh
@@ -14,7 +14,7 @@ mkdir -p "${SOURCES_DIR}" "${SERVERS_DIR}" "${CLIENTS_DIR}"
 
 setup_lakers() {
   # lakers
-  CHECKOUT="tags/v0.5.0"
+  CHECKOUT="tags/v0.5.1"
 
   set -e
   echo "Setting up Lakers in ${SOURCES_DIR}"

--- a/scripts/setup_sul.sh
+++ b/scripts/setup_sul.sh
@@ -14,7 +14,7 @@ mkdir -p "${SOURCES_DIR}" "${SERVERS_DIR}" "${CLIENTS_DIR}"
 
 setup_lakers() {
   # lakers
-  CHECKOUT="tags/v0.5.1"
+  CHECKOUT="tags/v0.6.0"
 
   set -e
   echo "Setting up Lakers in ${SOURCES_DIR}"


### PR DESCRIPTION
In the process of upgrading from 0.5.0 to 0.7.2, tested versions 0.5.1, 0.6.0, and 0.6.2.