### PR TITLE
Update to the latest protocol-state-fuzzer which uses generics

### DIFF
--- a/scripts/setup_fuzzer.sh
+++ b/scripts/setup_fuzzer.sh
@@ -8,7 +8,7 @@ readonly BASE_DIR
 setup_psf() {
     # setup protocol-state-fuzzer library
 
-    CHECKOUT="d665cb9d4396ced98131df70adb445150b4d3704"
+    CHECKOUT="d4d5730bbd9f7f93d8e9eee5165592586e03c833"
 
     set -e
     cd "${BASE_DIR}"

--- a/scripts/setup_fuzzer.sh
+++ b/scripts/setup_fuzzer.sh
@@ -8,14 +8,14 @@ readonly BASE_DIR
 setup_psf() {
     # setup protocol-state-fuzzer library
 
-    CHECKOUT="generics"
+    CHECKOUT="d665cb9d4396ced98131df70adb445150b4d3704"
 
     set -e
     cd "${BASE_DIR}"
     git clone "https://github.com/protocol-fuzzing/protocol-state-fuzzer.git"
     cd protocol-state-fuzzer
     git checkout ${CHECKOUT}
-    mvn install -DskipTests
+    bash ./install.sh
 
     cd "${BASE_DIR}"
     rm -rf ./protocol-state-fuzzer/

--- a/scripts/setup_fuzzer.sh
+++ b/scripts/setup_fuzzer.sh
@@ -8,8 +8,7 @@ readonly BASE_DIR
 setup_psf() {
     # setup protocol-state-fuzzer library
 
-    # this is the commit _just_ before Generics were introduced
-    CHECKOUT="398c9bc526c94294569e46286d43692b5171c175"
+    CHECKOUT="generics"
 
     set -e
     cd "${BASE_DIR}"

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/EdhocDotProcessor.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/EdhocDotProcessor.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class EdhocDotProcessor {
     private static final Logger LOGGER = LogManager.getLogger();
 
-    public static void beautify(LearnerResult learnerResult) {
+    public static void beautify(LearnerResult<?, ?> learnerResult) {
         if (learnerResult.isEmpty()) {
             LOGGER.warn("Provided empty LearnerResult");
             return;

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/EdhocDotProcessor.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/EdhocDotProcessor.java
@@ -14,7 +14,11 @@ import java.util.List;
 public class EdhocDotProcessor {
     private static final Logger LOGGER = LogManager.getLogger();
 
-    public static void beautify(LearnerResult<?, ?> learnerResult) {
+    public static void beautify(LearnerResult<?> learnerResult) {
+        if (learnerResult.isFromTest()) {
+            return;
+        }
+
         if (learnerResult.isEmpty()) {
             LOGGER.warn("Provided empty LearnerResult");
             return;

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/Main.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/Main.java
@@ -1,5 +1,7 @@
 package com.github.protocolfuzzing.edhocfuzzer;
 
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs.EdhocInput;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.outputs.EdhocOutput;
 import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParser;
 
 import java.util.List;
@@ -9,7 +11,7 @@ public class Main {
         MultiBuilder mb = new MultiBuilder();
         String[] parentLoggers = {Main.class.getPackageName()};
 
-        CommandLineParser commandLineParser = new CommandLineParser(mb, mb, mb, mb);
+        CommandLineParser<EdhocInput, EdhocOutput> commandLineParser = new CommandLineParser<>(mb, mb, mb, mb);
         commandLineParser.setExternalParentLoggers(parentLoggers);
 
         commandLineParser.parse(args, true, List.of(EdhocDotProcessor::beautify));

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/Main.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/Main.java
@@ -1,7 +1,5 @@
 package com.github.protocolfuzzing.edhocfuzzer;
 
-import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs.EdhocInput;
-import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.outputs.EdhocOutput;
 import com.github.protocolfuzzing.protocolstatefuzzer.entrypoints.CommandLineParser;
 
 import java.util.List;
@@ -11,7 +9,7 @@ public class Main {
         MultiBuilder mb = new MultiBuilder();
         String[] parentLoggers = {Main.class.getPackageName()};
 
-        CommandLineParser<EdhocInput, EdhocOutput> commandLineParser = new CommandLineParser<>(mb, mb, mb, mb);
+        CommandLineParser<?> commandLineParser = new CommandLineParser<>(mb, mb, mb, mb);
         commandLineParser.setExternalParentLoggers(parentLoggers);
 
         commandLineParser.parse(args, true, List.of(EdhocDotProcessor::beautify));

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/MultiBuilder.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/MultiBuilder.java
@@ -5,6 +5,9 @@ import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.EdhocSulBuilde
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.config.EdhocSulClientConfig;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.config.EdhocSulServerConfig;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config.EdhocMapperConfig;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocExecutionContext;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs.EdhocInput;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.outputs.EdhocOutput;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphabet.AlphabetBuilder;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphabet.AlphabetBuilderStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphabet.xml.AlphabetSerializerXml;
@@ -24,21 +27,23 @@ import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.St
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.core.config.StateFuzzerServerConfigStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.TestRunner;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.TestRunnerBuilder;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.TestRunnerStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.config.TestRunnerConfigStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.core.config.TestRunnerEnabler;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.TimingProbe;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.TimingProbeBuilder;
+import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.TimingProbeStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.config.TimingProbeConfigStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.config.TimingProbeEnabler;
 
-public class MultiBuilder implements StateFuzzerConfigBuilder, StateFuzzerBuilder, TestRunnerBuilder, TimingProbeBuilder {
+public class MultiBuilder implements StateFuzzerConfigBuilder, StateFuzzerBuilder<EdhocInput, EdhocOutput>, TestRunnerBuilder, TimingProbeBuilder {
 
-    protected AlphabetBuilder alphabetBuilder = new AlphabetBuilderStandard(
-            new AlphabetSerializerXml<>(EdhocAlphabetPojoXml.class)
+    protected AlphabetBuilder<EdhocInput> alphabetBuilder = new AlphabetBuilderStandard<>(
+        new AlphabetSerializerXml<EdhocInput, EdhocAlphabetPojoXml>(EdhocInput.class, EdhocAlphabetPojoXml.class)
     );
 
-    protected SulBuilder sulBuilder = new EdhocSulBuilder();
-    protected SulWrapper sulWrapper = new SulWrapperStandard();
+    protected SulBuilder<EdhocInput, EdhocOutput, EdhocExecutionContext> sulBuilder = new EdhocSulBuilder();
+    protected SulWrapper<EdhocInput, EdhocOutput, EdhocExecutionContext> sulWrapper = new SulWrapperStandard<>();
 
     @Override
     public StateFuzzerClientConfig buildClientConfig() {
@@ -61,19 +66,19 @@ public class MultiBuilder implements StateFuzzerConfigBuilder, StateFuzzerBuilde
     }
 
     @Override
-    public StateFuzzer build(StateFuzzerEnabler stateFuzzerEnabler) {
-        return new StateFuzzerStandard(
-                new StateFuzzerComposerStandard(stateFuzzerEnabler, alphabetBuilder, sulBuilder, sulWrapper).initialize()
+    public StateFuzzer<EdhocInput, EdhocOutput> build(StateFuzzerEnabler stateFuzzerEnabler) {
+        return new StateFuzzerStandard<>(
+            new StateFuzzerComposerStandard<>(stateFuzzerEnabler, alphabetBuilder, sulBuilder, sulWrapper).initialize()
         );
     }
 
     @Override
     public TestRunner build(TestRunnerEnabler testRunnerEnabler) {
-        return new TestRunner(testRunnerEnabler, alphabetBuilder, sulBuilder, sulWrapper).initialize();
+        return new TestRunnerStandard<>(testRunnerEnabler, alphabetBuilder, sulBuilder, sulWrapper).initialize();
     }
 
     @Override
     public TimingProbe build(TimingProbeEnabler timingProbeEnabler) {
-        return new TimingProbe(timingProbeEnabler, alphabetBuilder, sulBuilder, sulWrapper).initialize();
+        return new TimingProbeStandard<>(timingProbeEnabler, alphabetBuilder, sulBuilder, sulWrapper).initialize();
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/MultiBuilder.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/MultiBuilder.java
@@ -12,6 +12,7 @@ import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphabe
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphabet.AlphabetBuilderStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphabet.xml.AlphabetSerializerXml;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.config.LearnerConfigStandard;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.statistics.MealyMachineWrapper;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.SulBuilder;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.SulWrapper;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.SulWrapperStandard;
@@ -36,7 +37,11 @@ import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.tim
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.config.TimingProbeConfigStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.statefuzzer.testrunner.timingprobe.config.TimingProbeEnabler;
 
-public class MultiBuilder implements StateFuzzerConfigBuilder, StateFuzzerBuilder<EdhocInput, EdhocOutput>, TestRunnerBuilder, TimingProbeBuilder {
+public class MultiBuilder implements
+    StateFuzzerConfigBuilder,
+    StateFuzzerBuilder<MealyMachineWrapper<EdhocInput, EdhocOutput>>,
+    TestRunnerBuilder,
+    TimingProbeBuilder {
 
     protected AlphabetBuilder<EdhocInput> alphabetBuilder = new AlphabetBuilderStandard<>(
         new AlphabetSerializerXml<EdhocInput, EdhocAlphabetPojoXml>(EdhocInput.class, EdhocAlphabetPojoXml.class)
@@ -66,7 +71,7 @@ public class MultiBuilder implements StateFuzzerConfigBuilder, StateFuzzerBuilde
     }
 
     @Override
-    public StateFuzzer<EdhocInput, EdhocOutput> build(StateFuzzerEnabler stateFuzzerEnabler) {
+    public StateFuzzer<MealyMachineWrapper<EdhocInput, EdhocOutput>> build(StateFuzzerEnabler stateFuzzerEnabler) {
         return new StateFuzzerStandard<>(
             new StateFuzzerComposerStandard<>(stateFuzzerEnabler, alphabetBuilder, sulBuilder, sulWrapper).initialize()
         );

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/learner/EdhocAlphabetPojoXml.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/learner/EdhocAlphabetPojoXml.java
@@ -2,14 +2,17 @@ package com.github.protocolfuzzing.edhocfuzzer.components.learner;
 
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs.*;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.alphabet.xml.AlphabetPojoXml;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractInput;
-import jakarta.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElements;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import java.util.List;
 
 @XmlRootElement(name = "alphabet")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class EdhocAlphabetPojoXml extends AlphabetPojoXml {
+public class EdhocAlphabetPojoXml extends AlphabetPojoXml<EdhocInput> {
     @XmlElements(value = {
             @XmlElement(type = EdhocMessage1Input.class, name = "EdhocMessage1Input"),
             @XmlElement(type = EdhocMessage2Input.class, name = "EdhocMessage2Input"),
@@ -21,16 +24,16 @@ public class EdhocAlphabetPojoXml extends AlphabetPojoXml {
             @XmlElement(type = CoapAppMessageInput.class, name = "CoapAppMessageInput"),
             @XmlElement(type = CoapEmptyMessageInput.class, name = "CoapEmptyMessageInput")
     })
-    protected List<AbstractInput> inputs;
+    protected List<EdhocInput> inputs;
 
     public EdhocAlphabetPojoXml() {}
 
-    public EdhocAlphabetPojoXml(List<AbstractInput> inputs) {
+    public EdhocAlphabetPojoXml(List<EdhocInput> inputs) {
         this.inputs = inputs;
     }
 
     @Override
-    public List<AbstractInput> getInputs(){
+    public List<EdhocInput> getInputs(){
         return inputs;
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/EdhocSulBuilder.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/EdhocSulBuilder.java
@@ -1,13 +1,17 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.core;
 
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocExecutionContext;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs.EdhocInput;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.outputs.EdhocOutput;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.AbstractSul;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.SulBuilder;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.utils.CleanupTasks;
 
-public class EdhocSulBuilder implements SulBuilder {
+public class EdhocSulBuilder implements SulBuilder<EdhocInput, EdhocOutput, EdhocExecutionContext>{
     @Override
-    public AbstractSul build(SulConfig sulConfig, CleanupTasks cleanupTasks) {
+    public AbstractSul<EdhocInput, EdhocOutput, EdhocExecutionContext>
+    build(SulConfig sulConfig, CleanupTasks cleanupTasks) {
         return new EdhocSul(sulConfig, cleanupTasks).initialize();
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/config/EdhocSulClientConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/config/EdhocSulClientConfig.java
@@ -2,14 +2,14 @@ package com.github.protocolfuzzing.edhocfuzzer.components.sul.core.config;
 
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config.EdhocMapperConfig;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config.EdhocMapperConnectionConfig;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulAdapterConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulAdapterConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulClientConfigStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConfig;
 import org.eclipse.californium.elements.config.Configuration;
 
 public class EdhocSulClientConfig extends SulClientConfigStandard {
     public EdhocSulClientConfig(EdhocMapperConfig edhocMapperConfig) {
-        super(edhocMapperConfig, new SulAdapterConfigEmpty());
+        super(edhocMapperConfig, new SulAdapterConfig(){});
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/config/EdhocSulClientConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/config/EdhocSulClientConfig.java
@@ -5,7 +5,6 @@ import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config.Edhoc
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulAdapterConfigEmpty;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulClientConfigStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConfig;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConnectionConfig;
 import org.eclipse.californium.elements.config.Configuration;
 
 public class EdhocSulClientConfig extends SulClientConfigStandard {
@@ -20,7 +19,9 @@ public class EdhocSulClientConfig extends SulClientConfigStandard {
     }
 
     @Override
-    public void applyDelegate(MapperConnectionConfig config) {
-        Configuration.setStandard(((EdhocMapperConnectionConfig) config).getConfiguration());
+    public <MC> void applyDelegate(MC config) {
+        if (config instanceof EdhocMapperConnectionConfig) {
+            Configuration.setStandard(EdhocMapperConnectionConfig.class.cast(config).getConfiguration());
+        }
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/config/EdhocSulServerConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/config/EdhocSulServerConfig.java
@@ -2,14 +2,14 @@ package com.github.protocolfuzzing.edhocfuzzer.components.sul.core.config;
 
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config.EdhocMapperConfig;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config.EdhocMapperConnectionConfig;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulAdapterConfigEmpty;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulAdapterConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulServerConfigStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConfig;
 import org.eclipse.californium.elements.config.Configuration;
 
 public class EdhocSulServerConfig extends SulServerConfigStandard {
     public EdhocSulServerConfig(EdhocMapperConfig edhocMapperConfig) {
-        super(edhocMapperConfig, new SulAdapterConfigEmpty());
+        super(edhocMapperConfig, new SulAdapterConfig(){});
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/config/EdhocSulServerConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/config/EdhocSulServerConfig.java
@@ -5,7 +5,6 @@ import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config.Edhoc
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulAdapterConfigEmpty;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.config.SulServerConfigStandard;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConfig;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConnectionConfig;
 import org.eclipse.californium.elements.config.Configuration;
 
 public class EdhocSulServerConfig extends SulServerConfigStandard {
@@ -20,7 +19,9 @@ public class EdhocSulServerConfig extends SulServerConfigStandard {
     }
 
     @Override
-    public void applyDelegate(MapperConnectionConfig config) {
-        Configuration.setStandard(((EdhocMapperConnectionConfig) config).getConfiguration());
+    public <MC> void applyDelegate(MC config) {
+        if (config instanceof EdhocMapperConnectionConfig) {
+            Configuration.setStandard(EdhocMapperConnectionConfig.class.cast(config).getConfiguration());
+        }
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/messages/EdhocProtocolMessage.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/core/protocol/messages/EdhocProtocolMessage.java
@@ -1,11 +1,10 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages;
 
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.MessageProcessorPersistent;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage;
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.edhoc.Constants;
 
-public abstract class EdhocProtocolMessage implements ProtocolMessage {
+public abstract class EdhocProtocolMessage {
     // payload of the message
     protected byte[] payload;
 

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/EdhocMapperConnectionConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/EdhocMapperConnectionConfig.java
@@ -1,12 +1,11 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConnectionConfig;
 import org.eclipse.californium.core.config.CoapConfig;
 import org.eclipse.californium.elements.config.Configuration;
 
 import java.io.InputStream;
 
-public class EdhocMapperConnectionConfig implements MapperConnectionConfig {
+public class EdhocMapperConnectionConfig {
     private static boolean registered = false;
     private static void register() {
         if (!registered) {

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/ClientMapperState.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/ClientMapperState.java
@@ -1,15 +1,12 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context;
 
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config.EdhocMapperConfig;
-import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config.ProtocolVersion;
 import com.github.protocolfuzzing.protocolstatefuzzer.utils.CleanupTasks;
 
 public class ClientMapperState extends EdhocMapperState {
 
-    public ClientMapperState(ProtocolVersion protocolVersion,  EdhocMapperConfig edhocMapperConfig,
-                             CleanupTasks cleanupTasks) {
-        super(protocolVersion, edhocMapperConfig, edhocMapperConfig.getEdhocCoapUri(),
-              edhocMapperConfig.getEdhocCoapUri(), cleanupTasks);
+    public ClientMapperState(EdhocMapperConfig edhocMapperConfig, CleanupTasks cleanupTasks) {
+        super(edhocMapperConfig, edhocMapperConfig.getEdhocCoapUri(), edhocMapperConfig.getEdhocCoapUri(), cleanupTasks);
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/EdhocExecutionContext.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/EdhocExecutionContext.java
@@ -1,0 +1,19 @@
+package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context;
+
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs.EdhocInput;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.outputs.EdhocOutput;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContextStepped;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.StepContext;
+
+public class EdhocExecutionContext
+extends ExecutionContextStepped<EdhocInput, EdhocOutput, EdhocMapperState, StepContext<EdhocInput, EdhocOutput>> {
+
+    public EdhocExecutionContext(EdhocMapperState state) {
+        super(state);
+    }
+
+    @Override
+    protected StepContext<EdhocInput, EdhocOutput> buildStepContext() {
+        return new StepContext<>(stepContexts.size());
+    }
+}

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/EdhocMapperState.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/EdhocMapperState.java
@@ -12,7 +12,6 @@ import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config.authe
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config.authentication.TestVectorAuthenticationConfig;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.connectors.CoapExchanger;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.connectors.EdhocMapperConnector;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.State;
 import com.github.protocolfuzzing.protocolstatefuzzer.utils.CleanupTasks;
 import com.upokecenter.cbor.CBORObject;
 import net.i2p.crypto.eddsa.EdDSASecurityProvider;
@@ -26,7 +25,7 @@ import java.security.Security;
 import java.util.*;
 
 /** Adapted from test files EdhocClient / EdhocServer from edhoc repo */
-public abstract class EdhocMapperState implements State {
+public abstract class EdhocMapperState {
 
     // The protocol version of edhoc used for the session of this state
     protected ProtocolVersion protocolVersion;

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/EdhocMapperState.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/EdhocMapperState.java
@@ -27,12 +27,6 @@ import java.util.*;
 /** Adapted from test files EdhocClient / EdhocServer from edhoc repo */
 public abstract class EdhocMapperState {
 
-    // The protocol version of edhoc used for the session of this state
-    protected ProtocolVersion protocolVersion;
-
-    // The combined message (EDHOC+OSCORE) version used for the session of this state
-    protected CombinedMessageVersion combinedMessageVersion;
-
     // The authentication method to include in EDHOC message_1 (relevant only when Initiator)
     protected int authenticationMethod;
 
@@ -97,12 +91,9 @@ public abstract class EdhocMapperState {
 
     protected CleanupTasks cleanupTasks;
 
-    public EdhocMapperState(ProtocolVersion protocolVersion, EdhocMapperConfig edhocMapperConfig,
-                            String edhocSessionUri, String oscoreUri, CleanupTasks cleanupTasks) {
+    public EdhocMapperState(EdhocMapperConfig edhocMapperConfig, String edhocSessionUri, String oscoreUri, CleanupTasks cleanupTasks) {
 
-        this.protocolVersion = protocolVersion;
         this.edhocMapperConfig = edhocMapperConfig;
-        this.combinedMessageVersion = edhocMapperConfig.getCombinedMessageVersion();
         this.cleanupTasks = cleanupTasks;
 
         // Insert security providers
@@ -197,11 +188,11 @@ public abstract class EdhocMapperState {
     }
 
     public ProtocolVersion getProtocolVersion() {
-        return protocolVersion;
+        return edhocMapperConfig.getProtocolVersion();
     }
 
     public CombinedMessageVersion getCombinedMessageVersion() {
-        return combinedMessageVersion;
+        return edhocMapperConfig.getCombinedMessageVersion();
     }
 
     public EdhocSessionPersistent getEdhocSessionPersistent() {

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/ServerMapperState.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/context/ServerMapperState.java
@@ -1,15 +1,12 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context;
 
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config.EdhocMapperConfig;
-import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config.ProtocolVersion;
 import com.github.protocolfuzzing.protocolstatefuzzer.utils.CleanupTasks;
 
 public class ServerMapperState extends EdhocMapperState {
 
-    public ServerMapperState(ProtocolVersion protocolVersion, EdhocMapperConfig edhocMapperConfig,
-                             CleanupTasks cleanupTasks) {
-        super(protocolVersion, edhocMapperConfig, edhocMapperConfig.getEdhocCoapUri(),
-                edhocMapperConfig.getHostCoapUri(), cleanupTasks);
+    public ServerMapperState(EdhocMapperConfig edhocMapperConfig, CleanupTasks cleanupTasks) {
+        super(edhocMapperConfig, edhocMapperConfig.getEdhocCoapUri(), edhocMapperConfig.getHostCoapUri(), cleanupTasks);
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/mappers/EdhocInputMapper.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/mappers/EdhocInputMapper.java
@@ -6,7 +6,7 @@ import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.connectors.E
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocExecutionContext;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs.EdhocInput;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.outputs.EdhocOutput;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.OutputChecker;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.outputs.EdhocOutputChecker;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConfig;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.mappers.InputMapper;
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
@@ -14,7 +14,7 @@ import org.eclipse.californium.core.coap.MediaTypeRegistry;
 public class EdhocInputMapper extends InputMapper<EdhocInput, EdhocOutput, EdhocProtocolMessage, EdhocExecutionContext> {
     EdhocMapperConnector edhocMapperConnector;
 
-    public EdhocInputMapper(MapperConfig mapperConfig, OutputChecker<EdhocOutput> outputChecker, EdhocMapperConnector edhocMapperConnector) {
+    public EdhocInputMapper(MapperConfig mapperConfig, EdhocOutputChecker outputChecker, EdhocMapperConnector edhocMapperConnector) {
         super(mapperConfig, outputChecker);
         this.edhocMapperConnector = edhocMapperConnector;
     }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/mappers/EdhocInputMapper.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/mappers/EdhocInputMapper.java
@@ -28,7 +28,7 @@ public class EdhocInputMapper extends InputMapper<EdhocInput, EdhocOutput, Edhoc
         // enable or disable content format
         EdhocMapperConfig edhocMapperConfig = (EdhocMapperConfig) mapperConfig;
         int contentFormat = edhocMapperConfig.useContentFormat() ?
-            edhocProtocolMessage.getContentFormat(edhocMapperConfig.useOldContentFormat()) :
+            message.getContentFormat(edhocMapperConfig.useOldContentFormat()) :
             MediaTypeRegistry.UNDEFINED;
 
         edhocMapperConnector.send(message.getPayload(), message.getPayloadType(), message.getMessageCode(), contentFormat);

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/mappers/EdhocInputMapper.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/mappers/EdhocInputMapper.java
@@ -3,29 +3,27 @@ package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.mappers;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.EdhocProtocolMessage;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config.EdhocMapperConfig;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.connectors.EdhocMapperConnector;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutputChecker;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocExecutionContext;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs.EdhocInput;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.outputs.EdhocOutput;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.OutputChecker;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.config.MapperConfig;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.mappers.InputMapper;
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
 
-public class EdhocInputMapper extends InputMapper {
+public class EdhocInputMapper extends InputMapper<EdhocInput, EdhocOutput, EdhocProtocolMessage, EdhocExecutionContext> {
     EdhocMapperConnector edhocMapperConnector;
 
-    public EdhocInputMapper(MapperConfig mapperConfig, AbstractOutputChecker outputChecker,
-                            EdhocMapperConnector edhocMapperConnector) {
+    public EdhocInputMapper(MapperConfig mapperConfig, OutputChecker<EdhocOutput> outputChecker, EdhocMapperConnector edhocMapperConnector) {
         super(mapperConfig, outputChecker);
         this.edhocMapperConnector = edhocMapperConnector;
     }
 
     @Override
-    protected void sendMessage(ProtocolMessage message, ExecutionContext context) {
+    protected void sendMessage(EdhocProtocolMessage message, EdhocExecutionContext context) {
         if (message == null) {
             throw new RuntimeException("Null message provided to EdhocInputMapper in sendMessage");
         }
-
-        EdhocProtocolMessage edhocProtocolMessage = (EdhocProtocolMessage) message;
 
         // enable or disable content format
         EdhocMapperConfig edhocMapperConfig = (EdhocMapperConfig) mapperConfig;
@@ -33,7 +31,6 @@ public class EdhocInputMapper extends InputMapper {
             edhocProtocolMessage.getContentFormat(edhocMapperConfig.useOldContentFormat()) :
             MediaTypeRegistry.UNDEFINED;
 
-        edhocMapperConnector.send(edhocProtocolMessage.getPayload(), edhocProtocolMessage.getPayloadType(),
-                edhocProtocolMessage.getMessageCode(), contentFormat);
+        edhocMapperConnector.send(message.getPayload(), message.getPayloadType(), message.getMessageCode(), contentFormat);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/mappers/EdhocMapperComposer.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/mappers/EdhocMapperComposer.java
@@ -1,0 +1,26 @@
+package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.mappers;
+
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.EdhocProtocolMessage;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocExecutionContext;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocMapperState;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs.EdhocInput;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.outputs.EdhocOutput;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.outputs.EdhocOutputBuilder;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.outputs.EdhocOutputChecker;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.mappers.MapperComposer;
+
+public class EdhocMapperComposer extends MapperComposer<EdhocInput, EdhocOutput, EdhocProtocolMessage, EdhocExecutionContext, EdhocMapperState> {
+    public EdhocMapperComposer(EdhocInputMapper edhocInputMapper, EdhocOutputMapper edhocOutputMapper) {
+        super(edhocInputMapper, edhocOutputMapper);
+    }
+
+    @Override
+    public EdhocOutputChecker getOutputChecker() {
+        return (EdhocOutputChecker) super.getOutputChecker();
+    }
+
+    @Override
+    public EdhocOutputBuilder getOutputBuilder() {
+        return (EdhocOutputBuilder) super.getOutputBuilder();
+    }
+}

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/CoapAppMessageInput.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/CoapAppMessageInput.java
@@ -1,15 +1,15 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs;
 
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.MessageProcessorPersistent;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.EdhocProtocolMessage;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.common.CoapAppMessage;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocExecutionContext;
 
 public class CoapAppMessageInput extends EdhocInput {
 
     @Override
-    public ProtocolMessage generateProtocolMessage(ExecutionContext context) {
-        return new CoapAppMessage(new MessageProcessorPersistent(getEdhocMapperState(context)));
+    public EdhocProtocolMessage generateProtocolMessage(EdhocExecutionContext context) {
+        return new CoapAppMessage(new MessageProcessorPersistent(context.getState()));
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/CoapEmptyMessageInput.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/CoapEmptyMessageInput.java
@@ -1,15 +1,15 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs;
 
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.MessageProcessorPersistent;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.EdhocProtocolMessage;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.common.CoapEmptyMessage;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocExecutionContext;
 
 public class CoapEmptyMessageInput extends EdhocInput {
 
     @Override
-    public ProtocolMessage generateProtocolMessage(ExecutionContext context) {
-        return new CoapEmptyMessage(new MessageProcessorPersistent(getEdhocMapperState(context)));
+    public EdhocProtocolMessage generateProtocolMessage(EdhocExecutionContext context) {
+        return new CoapEmptyMessage(new MessageProcessorPersistent(context.getState()));
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/EdhocErrorMessageInput.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/EdhocErrorMessageInput.java
@@ -1,15 +1,15 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs;
 
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.MessageProcessorPersistent;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.EdhocProtocolMessage;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.common.EdhocErrorMessage;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocExecutionContext;
 
 public class EdhocErrorMessageInput extends EdhocInput {
 
     @Override
-    public ProtocolMessage generateProtocolMessage(ExecutionContext context) {
-        return new EdhocErrorMessage(new MessageProcessorPersistent(getEdhocMapperState(context)));
+    public EdhocProtocolMessage generateProtocolMessage(EdhocExecutionContext context) {
+        return new EdhocErrorMessage(new MessageProcessorPersistent(context.getState()));
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/EdhocInput.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/EdhocInput.java
@@ -1,28 +1,23 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs;
 
-import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.EdhocSessionPersistent;
-import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocMapperState;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutput;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutputChecker;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.xml.AbstractInputXml;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.EdhocProtocolMessage;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocExecutionContext;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.outputs.EdhocOutput;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractInputXml;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.OutputChecker;
 
-public abstract class EdhocInput extends AbstractInputXml {
-    public EdhocMapperState getEdhocMapperState(ExecutionContext context) {
-        return (EdhocMapperState) context.getState();
-    }
-
-    public EdhocSessionPersistent getEdhocSessionPersistent(ExecutionContext context) {
-        return getEdhocMapperState(context).getEdhocSessionPersistent();
-    }
+public abstract class EdhocInput extends AbstractInputXml<EdhocOutput, EdhocProtocolMessage, EdhocExecutionContext> {
+    public abstract Enum<MessageInputType> getInputType();
 
     @Override
-    public void preSendUpdate(ExecutionContext context) {}
+    public void preSendUpdate(EdhocExecutionContext context) {}
 
     @Override
-    public void postSendUpdate(ExecutionContext context) {}
+    public void postSendUpdate(EdhocExecutionContext context) {}
 
     @Override
-    public void postReceiveUpdate(AbstractOutput output, AbstractOutputChecker abstractOutputChecker,
-                                  ExecutionContext context) {}
+    public void postReceiveUpdate(
+        EdhocOutput output,
+        OutputChecker<EdhocOutput> abstractOutputChecker,
+        EdhocExecutionContext context) {}
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/EdhocMessage1Input.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/EdhocMessage1Input.java
@@ -1,24 +1,27 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs;
 
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.EdhocSessionPersistent;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.MessageProcessorPersistent;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.EdhocProtocolMessage;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.initiator.EdhocMessage1;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocExecutionContext;
 
 public class EdhocMessage1Input extends EdhocInput {
 
     @Override
-    public void preSendUpdate(ExecutionContext context) {
-        if (getEdhocSessionPersistent(context).isInitiator()) {
+    public void preSendUpdate(EdhocExecutionContext context) {
+        EdhocSessionPersistent session = context.getState().getEdhocSessionPersistent();
+
+        if (session.isInitiator()) {
             // Initiator by sending message 1 starts a new key exchange session
             // so previous session state must be cleaned unless reset is disabled
-            getEdhocSessionPersistent(context).resetIfEnabled();
+            session.resetIfEnabled();
         }
     }
 
     @Override
-    public ProtocolMessage generateProtocolMessage(ExecutionContext context) {
-        return new EdhocMessage1(new MessageProcessorPersistent(getEdhocMapperState(context)));
+    public EdhocProtocolMessage generateProtocolMessage(EdhocExecutionContext context) {
+        return new EdhocMessage1(new MessageProcessorPersistent(context.getState()));
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/EdhocMessage2Input.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/EdhocMessage2Input.java
@@ -1,15 +1,15 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs;
 
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.MessageProcessorPersistent;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.EdhocProtocolMessage;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.responder.EdhocMessage2;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocExecutionContext;
 
 public class EdhocMessage2Input extends EdhocInput {
 
     @Override
-    public ProtocolMessage generateProtocolMessage(ExecutionContext context) {
-        return new EdhocMessage2(new MessageProcessorPersistent(getEdhocMapperState(context)));
+    public EdhocProtocolMessage generateProtocolMessage(EdhocExecutionContext context) {
+        return new EdhocMessage2(new MessageProcessorPersistent(context.getState()));
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/EdhocMessage3Input.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/EdhocMessage3Input.java
@@ -1,15 +1,15 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs;
 
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.MessageProcessorPersistent;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.EdhocProtocolMessage;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.initiator.EdhocMessage3;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocExecutionContext;
 
 public class EdhocMessage3Input extends EdhocInput {
 
     @Override
-    public ProtocolMessage generateProtocolMessage(ExecutionContext context) {
-        return new EdhocMessage3(new MessageProcessorPersistent(getEdhocMapperState(context)));
+    public EdhocProtocolMessage generateProtocolMessage(EdhocExecutionContext context) {
+        return new EdhocMessage3(new MessageProcessorPersistent(context.getState()));
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/EdhocMessage3OscoreAppInput.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/EdhocMessage3OscoreAppInput.java
@@ -1,22 +1,22 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs;
 
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.MessageProcessorPersistent;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.EdhocProtocolMessage;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.initiator.EdhocMessage3OscoreApp;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocExecutionContext;
 
 public class EdhocMessage3OscoreAppInput extends EdhocInput {
 
     @Override
-    public void preSendUpdate(ExecutionContext context) {
+    public void preSendUpdate(EdhocExecutionContext context) {
         // construct Message3 in order to store it in session 'message3' field,
         // derive new oscore context and make Message3 available to oscore layer
-        new MessageProcessorPersistent(getEdhocMapperState(context)).writeMessage3();
+        new MessageProcessorPersistent(context.getState()).writeMessage3();
     }
 
     @Override
-    public ProtocolMessage generateProtocolMessage(ExecutionContext context) {
-        return new EdhocMessage3OscoreApp(new MessageProcessorPersistent(getEdhocMapperState(context)));
+    public EdhocProtocolMessage generateProtocolMessage(EdhocExecutionContext context) {
+        return new EdhocMessage3OscoreApp(new MessageProcessorPersistent(context.getState()));
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/EdhocMessage4Input.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/EdhocMessage4Input.java
@@ -1,15 +1,15 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs;
 
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.MessageProcessorPersistent;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.EdhocProtocolMessage;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.responder.EdhocMessage4;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocExecutionContext;
 
 public class EdhocMessage4Input extends EdhocInput {
 
     @Override
-    public ProtocolMessage generateProtocolMessage(ExecutionContext context) {
-        return new EdhocMessage4(new MessageProcessorPersistent(getEdhocMapperState(context)));
+    public EdhocProtocolMessage generateProtocolMessage(EdhocExecutionContext context) {
+        return new EdhocMessage4(new MessageProcessorPersistent(context.getState()));
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/OscoreAppMessageInput.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/inputs/OscoreAppMessageInput.java
@@ -1,15 +1,15 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.inputs;
 
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.MessageProcessorPersistent;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.EdhocProtocolMessage;
 import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.common.OscoreAppMessage;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.core.protocol.ProtocolMessage;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.context.ExecutionContext;
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.context.EdhocExecutionContext;
 
 public class OscoreAppMessageInput extends EdhocInput {
 
     @Override
-    public ProtocolMessage generateProtocolMessage(ExecutionContext context) {
-        return new OscoreAppMessage(new MessageProcessorPersistent(getEdhocMapperState(context)));
+    public EdhocProtocolMessage generateProtocolMessage(EdhocExecutionContext context) {
+        return new OscoreAppMessage(new MessageProcessorPersistent(context.getState()));
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/outputs/EdhocOutput.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/outputs/EdhocOutput.java
@@ -1,0 +1,26 @@
+package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.outputs;
+
+import com.github.protocolfuzzing.edhocfuzzer.components.sul.core.protocol.messages.EdhocProtocolMessage;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutput;
+
+import java.util.List;
+
+public class EdhocOutput extends AbstractOutput<EdhocOutput, EdhocProtocolMessage> {
+    public EdhocOutput(String name) {
+        super(name);
+    }
+
+    public EdhocOutput(String name, List<EdhocProtocolMessage> messages) {
+        super(name, messages);
+    }
+
+    @Override
+    protected EdhocOutput buildOutput(String name) {
+        return new EdhocOutput(name);
+    }
+
+    @Override
+    protected EdhocOutput convertOutput() {
+        return new EdhocOutput(name, messages);
+    }
+}

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/outputs/EdhocOutputBuilder.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/outputs/EdhocOutputBuilder.java
@@ -1,0 +1,10 @@
+package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.outputs;
+
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.OutputBuilder;
+
+public class EdhocOutputBuilder implements OutputBuilder<EdhocOutput> {
+    @Override
+    public EdhocOutput buildOutput(String name) {
+        return new EdhocOutput(name);
+    }
+}

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/outputs/EdhocOutputChecker.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/outputs/EdhocOutputChecker.java
@@ -1,18 +1,37 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.outputs;
 
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutput;
-import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutputChecker;
+import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.OutputChecker;
 
 import java.util.Objects;
 
-public class EdhocOutputChecker implements AbstractOutputChecker {
+public class EdhocOutputChecker implements OutputChecker<EdhocOutput> {
 
-    public boolean isMessage(AbstractOutput abstractOutput, MessageOutputType messageOutputType) {
-        return Objects.equals(abstractOutput.getName(), messageOutputType.name());
+    public boolean isMessage(EdhocOutput output, MessageOutputType messageOutputType) {
+        return Objects.equals(output.getName(), messageOutputType.name());
     }
 
     @Override
-    public boolean hasInitialClientMessage(AbstractOutput abstractOutput) {
-        return isMessage(abstractOutput, MessageOutputType.EDHOC_MESSAGE_1);
+    public boolean hasInitialClientMessage(EdhocOutput output) {
+        return isMessage(output, MessageOutputType.EDHOC_MESSAGE_1);
+    }
+
+    @Override
+    public boolean isTimeout(EdhocOutput output) {
+        return isMessage(output, MessageOutputType.TIMEOUT);
+    }
+
+    @Override
+    public boolean isUnknown(EdhocOutput output) {
+        return isMessage(output, MessageOutputType.UNKNOWN);
+    }
+
+    @Override
+    public boolean isSocketClosed(EdhocOutput output) {
+        return isMessage(output, MessageOutputType.SOCKET_CLOSED);
+    }
+
+    @Override
+    public boolean isDisabled(EdhocOutput output) {
+        return isMessage(output, MessageOutputType.DISABLED);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/outputs/MessageOutputType.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/outputs/MessageOutputType.java
@@ -1,10 +1,8 @@
 package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.outputs;
 
 /** Messages that can be received.
- *  Possible additional messages not included are those generated from
- *  {@link com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutput#unknown() AbstractOutput.unknown()},
- *  {@link com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutput#socketClosed() AbstractOutput.socketClosed()},
- *  {@link com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.AbstractOutput#timeout() AbstractOutput.timeout()} */
+ * The last four are from the OutputBuilder.
+ */
 public enum MessageOutputType {
     EDHOC_MESSAGE_1,
     EDHOC_MESSAGE_2,
@@ -18,5 +16,9 @@ public enum MessageOutputType {
     COAP_ERROR_MESSAGE,
     COAP_EMPTY_MESSAGE,
     UNSUPPORTED_MESSAGE,
-    UNSUCCESSFUL_MESSAGE
+    UNSUCCESSFUL_MESSAGE,
+    TIMEOUT,
+    UNKNOWN,
+    SOCKET_CLOSED,
+    DISABLED
 }


### PR DESCRIPTION
This is the `generics` branch as adjusted to use the 21/2/2025 commit of [protocol-state-fuzzer](https://github.com/protocol-fuzzing/protocol-state-fuzzer) which supports learning both of Mealy machine models (via [learnlib](https://github.com/LearnLib/learnlib)) and of register automata (via [ralib](https://github.com/LearnLib/ralib/)).

It is the first step towards supporting learning of RA models for EDHOC implementations.