### PR TITLE
Fix the lakers CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y
           source "${HOME}/.cargo/env"
+          rustup toolchain install nightly-2024-06-22-x86_64-unknown-linux-gnu
           ./scripts/setup_sul.sh lakers
 
       - name: Test Lakers Server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y
           source "${HOME}/.cargo/env"
+          rustup toolchain install nightly-2024-06-22-x86_64-unknown-linux-gnu
           ./scripts/setup_sul.sh lakers
 
       - name: Test Lakers Client


### PR DESCRIPTION
Explicitly force in the CI the installation of the Rust tool chain specified in the lakers code base.
Unfortunately, the version is hard-coded in the CI command instead of being taken from the `lakers/rust-toolchain` file.