### PR TITLE
Update protocol-state-fuzzer

### DIFF
--- a/scripts/setup_fuzzer.sh
+++ b/scripts/setup_fuzzer.sh
@@ -8,7 +8,7 @@ readonly BASE_DIR
 setup_psf() {
     # setup protocol-state-fuzzer library
 
-    CHECKOUT="d4d5730bbd9f7f93d8e9eee5165592586e03c833"
+    CHECKOUT="2b4e4418b939603e0427853879b03eaca40a4be9"
 
     set -e
     cd "${BASE_DIR}"

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/outputs/EdhocOutputBuilder.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/symbols/outputs/EdhocOutputBuilder.java
@@ -2,9 +2,9 @@ package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.symbols.out
 
 import com.github.protocolfuzzing.protocolstatefuzzer.components.sul.mapper.abstractsymbols.OutputBuilder;
 
-public class EdhocOutputBuilder implements OutputBuilder<EdhocOutput> {
+public class EdhocOutputBuilder extends OutputBuilder<EdhocOutput> {
     @Override
-    public EdhocOutput buildOutput(String name) {
+    public EdhocOutput buildOutputExact(String name) {
         return new EdhocOutput(name);
     }
 }


### PR DESCRIPTION
I advanced the commit hash of protocol-state-fuzzer and made the necessary `EdhocOutputBuilder` changes for the compilation to work.

I should also note, that currently we do not actively use the symbol replacement feature in our experiments, e.g. `-socketClosedAsTimeout` or `-disabledAsTimeout`, so the changes should not affect the tests.