### PR TITLE
Update Lakers to version of 12th May 2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y
           source "${HOME}/.cargo/env"
-          rustup toolchain install nightly-2024-06-22-x86_64-unknown-linux-gnu
+          rustup toolchain install nightly-2025-03-31-x86_64-unknown-linux-gnu
           ./scripts/setup_sul.sh lakers
 
       - name: Test Lakers Client
@@ -54,7 +54,7 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y
           source "${HOME}/.cargo/env"
-          rustup toolchain install nightly-2024-06-22-x86_64-unknown-linux-gnu
+          rustup toolchain install nightly-2025-03-31-x86_64-unknown-linux-gnu
           ./scripts/setup_sul.sh lakers
 
       - name: Test Lakers Server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y
           source "${HOME}/.cargo/env"
-          rustup toolchain install nightly-2025-03-31-x86_64-unknown-linux-gnu
+          rustup toolchain install nightly-2025-05-10-x86_64-unknown-linux-gnu
           ./scripts/setup_sul.sh lakers
 
       - name: Test Lakers Client
@@ -54,7 +54,7 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y
           source "${HOME}/.cargo/env"
-          rustup toolchain install nightly-2025-03-31-x86_64-unknown-linux-gnu
+          rustup toolchain install nightly-2025-05-10-x86_64-unknown-linux-gnu
           ./scripts/setup_sul.sh lakers
 
       - name: Test Lakers Server

--- a/scripts/setup_sul.sh
+++ b/scripts/setup_sul.sh
@@ -13,8 +13,8 @@ readonly CLIENTS_DIR="${MODEL_DIR}/clients"
 mkdir -p "${SOURCES_DIR}" "${SERVERS_DIR}" "${CLIENTS_DIR}"
 
 setup_lakers() {
-  # lakers
-  CHECKOUT="tags/v0.8.0"
+  # lakers - commit SHA of 12/05/2025 updating to rust 182
+  CHECKOUT="13d9fcbf00922d7c87f940512dee1d6f18392a3b"
 
   set -e
   echo "Setting up Lakers in ${SOURCES_DIR}"


### PR DESCRIPTION
The Rust version used by the CI cannot be used to compile Lakers v0.8.0 anymore.

Rather than fighting with how to downgrade Rust versions in the CI, this PR updates the commit SHA of Lakers to that of May 12, 2025 which solves that particular problem.  Perhaps once a new tagged Lakers version is available, we should switch to that one.