### PR TITLE
Refine run description

### DIFF
--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/EdhocMapperConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/EdhocMapperConfig.java
@@ -243,25 +243,25 @@ public class EdhocMapperConfig extends MapperConfigStandard {
     public void printRunDescriptionSelf(PrintWriter printWriter) {
         super.printRunDescriptionSelf(printWriter);
         printWriter.println();
-        printWriter.println("EdhocMapperConfig Parameters");
-        printWriter.println("Protocol Version: " + getProtocolVersion());
-        printWriter.println("Combined Message Version: " + getCombinedMessageVersion());
-        printWriter.println("Edhoc Role: " + edhocRole);
-        printWriter.println("Edhoc Coap Resource: " + getEdhocCoapResource());
-        printWriter.println("App Coap Resource: " + getAppCoapResource());
-        printWriter.println("App Message Code To Coap Server: " + getAppMessageCodeToCoapServer());
-        printWriter.println("App Message Payload To Coap Server: " + getAppMessagePayloadToCoapServer());
-        printWriter.println("App Message Code To Coap Client: " + getAppMessageCodeToCoapClient());
-        printWriter.println("App Message Payload To Coap Client: " + getAppMessagePayloadToCoapClient());
-        printWriter.println("Coap Error As Edhoc Error: " + isCoapErrorAsEdhocError());
-        printWriter.println("use Content Format: " + useContentFormat());
-        printWriter.println("use Old Content Format: " + useOldContentFormat());
-        printWriter.println("use Session Reset: " + useSessionReset());
-        printWriter.println("use CX Correlation: " + useCXCorrelation());
-        printWriter.println("Own Connection Id: " + this.ownConnectionId);
-        printWriter.println("Generate Own Connection Id: " + generateOwnConnectionId());
-        printWriter.println("Force Oscore Sender Id: " + this.forceOscoreSenderId);
-        printWriter.println("Force Oscore Recipient Id: " + this.forceOscoreRecipientId);
+        printWriter.println("### EdhocMapperConfig Parameters");
+        printRunDescriptionNullableParam(printWriter, "-protocolVersion", protocolVersion);
+        printWriter.println("-combinedMessageVersion\n" + combinedMessageVersion);
+        printWriter.println("-edhocRole\n" + edhocRole);
+        printWriter.println("-edhocCoapResource\n" + edhocCoapResource);
+        printWriter.println("-appCoapResource\n" + appCoapResource);
+        printWriter.println("-appMessageCodeToCoapServer\n" + appMessageCodeToCoapServer);
+        printWriter.println("-appMessagePayloadToCoapServer\n" + appMessagePayloadToCoapServer);
+        printWriter.println("-appMessageCodeToCoapClient\n" + appMessageCodeToCoapClient);
+        printWriter.println("-appMessagePayloadToCoapClient\n" + appMessagePayloadToCoapClient);
+        printRunDescriptionBooleanParam(printWriter, "-coapErrorAsEdhocError", coapErrorAsEdhocError, false);
+        printRunDescriptionBooleanParam(printWriter, "-disableContentFormat", disableContentFormat, false);
+        printRunDescriptionBooleanParam(printWriter, "-useOldContentFormat", useOldContentFormat, false);
+        printRunDescriptionBooleanParam(printWriter, "-enableSessionReset", enableSessionReset, false);
+        printRunDescriptionBooleanParam(printWriter, "-disableCXCorrelation", disableCXCorrelation, false);
+        printWriter.println("-ownConnectionId\n" + ownConnectionId);
+        printRunDescriptionBooleanParam(printWriter, "-disableOwnConnectionIdGeneration\n", disableOwnConnectionIdGeneration, false);
+        printRunDescriptionNullableParam(printWriter, "-forceOscoreSenderId", forceOscoreSenderId);
+        printRunDescriptionNullableParam(printWriter, "-forceOscoreRecipientId", forceOscoreRecipientId);
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/EdhocMapperConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/EdhocMapperConfig.java
@@ -244,24 +244,24 @@ public class EdhocMapperConfig extends MapperConfigStandard {
         super.printRunDescriptionSelf(printWriter);
         printWriter.println();
         printWriter.println("### EdhocMapperConfig Parameters");
-        printRunDescriptionNullableParam(printWriter, "-protocolVersion", protocolVersion);
-        printWriter.println("-combinedMessageVersion\n" + combinedMessageVersion);
-        printWriter.println("-edhocRole\n" + edhocRole);
-        printWriter.println("-edhocCoapResource\n" + edhocCoapResource);
-        printWriter.println("-appCoapResource\n" + appCoapResource);
-        printWriter.println("-appMessageCodeToCoapServer\n" + appMessageCodeToCoapServer);
-        printWriter.println("-appMessagePayloadToCoapServer\n" + appMessagePayloadToCoapServer);
-        printWriter.println("-appMessageCodeToCoapClient\n" + appMessageCodeToCoapClient);
-        printWriter.println("-appMessagePayloadToCoapClient\n" + appMessagePayloadToCoapClient);
-        printRunDescriptionBooleanParam(printWriter, "-coapErrorAsEdhocError", coapErrorAsEdhocError, false);
-        printRunDescriptionBooleanParam(printWriter, "-disableContentFormat", disableContentFormat, false);
-        printRunDescriptionBooleanParam(printWriter, "-useOldContentFormat", useOldContentFormat, false);
-        printRunDescriptionBooleanParam(printWriter, "-enableSessionReset", enableSessionReset, false);
-        printRunDescriptionBooleanParam(printWriter, "-disableCXCorrelation", disableCXCorrelation, false);
-        printWriter.println("-ownConnectionId\n" + ownConnectionId);
-        printRunDescriptionBooleanParam(printWriter, "-disableOwnConnectionIdGeneration\n", disableOwnConnectionIdGeneration, false);
-        printRunDescriptionNullableParam(printWriter, "-forceOscoreSenderId", forceOscoreSenderId);
-        printRunDescriptionNullableParam(printWriter, "-forceOscoreRecipientId", forceOscoreRecipientId);
+        printRDParam(printWriter, "-protocolVersion", protocolVersion);
+        printRDParam(printWriter, "-combinedMessageVersion", combinedMessageVersion);
+        printRDParam(printWriter, "-edhocRole", edhocRole);
+        printRDStringParam(printWriter, "-edhocCoapResource", edhocCoapResource);
+        printRDStringParam(printWriter, "-appCoapResource", appCoapResource);
+        printRDStringParam(printWriter, "-appMessageCodeToCoapServer", appMessageCodeToCoapServer);
+        printRDStringParam(printWriter, "-appMessagePayloadToCoapServer", appMessagePayloadToCoapServer);
+        printRDStringParam(printWriter, "-appMessageCodeToCoapClient", appMessageCodeToCoapClient);
+        printRDStringParam(printWriter, "-appMessagePayloadToCoapClient", appMessagePayloadToCoapClient);
+        printRDBooleanParam(printWriter, "-coapErrorAsEdhocError", coapErrorAsEdhocError);
+        printRDBooleanParam(printWriter, "-disableContentFormat", disableContentFormat);
+        printRDBooleanParam(printWriter, "-useOldContentFormat", useOldContentFormat);
+        printRDBooleanParam(printWriter, "-enableSessionReset", enableSessionReset);
+        printRDBooleanParam(printWriter, "-disableCXCorrelation", disableCXCorrelation);
+        printRDStringParam(printWriter, "-ownConnectionId", ownConnectionId);
+        printRDBooleanParam(printWriter, "-disableOwnConnectionIdGeneration", disableOwnConnectionIdGeneration);
+        printRDStringParam(printWriter, "-forceOscoreSenderId", forceOscoreSenderId);
+        printRDStringParam(printWriter, "-forceOscoreRecipientId", forceOscoreRecipientId);
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/AuthenticationConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/AuthenticationConfig.java
@@ -72,11 +72,11 @@ public class AuthenticationConfig implements RunDescriptionPrinter {
     @Override
     public void printRunDescriptionSelf(PrintWriter printWriter) {
         printWriter.println("### AuthenticationConfig Parameters");
-        printRunDescriptionNullableParam(printWriter, "-mapCredType", mapCredType);
-        printRunDescriptionNullableParam(printWriter, "-mapIdCredType", mapIdCredType);
-        printRunDescriptionNullableParam(printWriter, "-sulCredType", sulCredType);
-        printRunDescriptionNullableParam(printWriter, "-sulIdCredType", sulIdCredType);
-        printWriter.println("-trustModel\n" + trustModel);
+        printRDParam(printWriter, "-mapCredType", mapCredType);
+        printRDParam(printWriter, "-mapIdCredType", mapIdCredType);
+        printRDParam(printWriter, "-sulCredType", sulCredType);
+        printRDParam(printWriter, "-sulIdCredType", sulIdCredType);
+        printRDParam(printWriter, "-trustModel", trustModel);
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/AuthenticationConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/AuthenticationConfig.java
@@ -71,12 +71,12 @@ public class AuthenticationConfig implements RunDescriptionPrinter {
 
     @Override
     public void printRunDescriptionSelf(PrintWriter printWriter) {
-        printWriter.println("AuthenticationConfig Parameters");
-        printWriter.println("Map Cred Type: " + mapCredType);
-        printWriter.println("Map Id Cred Type: " + mapIdCredType);
-        printWriter.println("Sul Cred Type: " + sulCredType);
-        printWriter.println("Sul Id Cred Type: " + sulIdCredType);
-        printWriter.println("Trust Model: " + trustModel);
+        printWriter.println("### AuthenticationConfig Parameters");
+        printRunDescriptionNullableParam(printWriter, "-mapCredType", mapCredType);
+        printRunDescriptionNullableParam(printWriter, "-mapIdCredType", mapIdCredType);
+        printRunDescriptionNullableParam(printWriter, "-sulCredType", sulCredType);
+        printRunDescriptionNullableParam(printWriter, "-sulIdCredType", sulIdCredType);
+        printWriter.println("-trustModel\n" + trustModel);
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/ManyFilesAuthenticationConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/ManyFilesAuthenticationConfig.java
@@ -71,9 +71,9 @@ public class ManyFilesAuthenticationConfig implements RunDescriptionPrinter {
 
     @Override
     public void printRunDescriptionSelf(PrintWriter printWriter) {
-        printWriter.println("ManyFilesAuthenticationConfig Parameters");
-        printWriter.println("Map Authentication Method" + mapAuthenticationMethod);
-        printWriter.println("Map Supported Cipher Suites" + mapSupportedCipherSuites);
+        printWriter.println("### ManyFilesAuthenticationConfig Parameters");
+        printRunDescriptionNullableParam(printWriter, "-mapAuthenticationMethod", mapAuthenticationMethod);
+        printRunDescriptionNullableParam(printWriter, "-mapSupportedCipherSuites\n", mapSupportedCipherSuites);
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/ManyFilesAuthenticationConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/ManyFilesAuthenticationConfig.java
@@ -72,8 +72,8 @@ public class ManyFilesAuthenticationConfig implements RunDescriptionPrinter {
     @Override
     public void printRunDescriptionSelf(PrintWriter printWriter) {
         printWriter.println("### ManyFilesAuthenticationConfig Parameters");
-        printRunDescriptionNullableParam(printWriter, "-mapAuthenticationMethod", mapAuthenticationMethod);
-        printRunDescriptionNullableParam(printWriter, "-mapSupportedCipherSuites\n", mapSupportedCipherSuites);
+        printRDParam(printWriter, "-mapAuthenticationMethod", mapAuthenticationMethod);
+        printRDListParam(printWriter, "-mapSupportedCipherSuites", mapSupportedCipherSuites);
     }
 
     @Override

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/TestVectorAuthenticationConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/TestVectorAuthenticationConfig.java
@@ -71,8 +71,8 @@ public class TestVectorAuthenticationConfig implements RunDescriptionPrinter {
     @Override
     public void printRunDescriptionSelf(PrintWriter printWriter) {
         printWriter.println("### TestVectorAuthenticationConfig Parameters");
-        printRunDescriptionNullableParam(printWriter, "-testVectorFile", testVectorFile);
-        printRunDescriptionNullableParam(printWriter, "-testVectorJsonKey", testVectorJsonKey);
-        printRunDescriptionNullableParam(printWriter, "-testVectorPeerKeyCurve", testVectorPeerKeyCurve);
+        printRDStringParam(printWriter, "-testVectorJson", testVectorFile);
+        printRDStringParam(printWriter, "-testVectorJsonKey", testVectorJsonKey);
+        printRDStringParam(printWriter, "-testVectorPeerKeyCurve", testVectorPeerKeyCurve);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/TestVectorAuthenticationConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/TestVectorAuthenticationConfig.java
@@ -70,9 +70,9 @@ public class TestVectorAuthenticationConfig implements RunDescriptionPrinter {
 
     @Override
     public void printRunDescriptionSelf(PrintWriter printWriter) {
-        printWriter.println("TestVectorAuthenticationConfig Parameters");
-        printWriter.println("Test Vector File: " + getTestVectorFile());
-        printWriter.println("Test Vector Key: " + getTestVectorKey());
-        printWriter.println("Test Vector Peer Key Curve: " + getTestVectorPeerKeyCurve());
+        printWriter.println("### TestVectorAuthenticationConfig Parameters");
+        printRunDescriptionNullableParam(printWriter, "-testVectorFile", testVectorFile);
+        printRunDescriptionNullableParam(printWriter, "-testVectorJsonKey", testVectorJsonKey);
+        printRunDescriptionNullableParam(printWriter, "-testVectorPeerKeyCurve", testVectorPeerKeyCurve);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/Ed25519KeySigConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/Ed25519KeySigConfig.java
@@ -85,7 +85,15 @@ public class Ed25519KeySigConfig implements KeyConfig {
 
     @Override
     public void printRunDescriptionSelf(PrintWriter printWriter) {
-        printWriter.println("Ed25519KeySigConfig Parameters");
-        KeyConfig.super.printRunDescriptionSelf(printWriter);
+        printWriter.println("### Ed25519KeySigConfig Parameters");
+        printRunDescriptionNullableParam(printWriter, "-mapEd25519PrivKeySig", mapPrivateFilename);
+        printRunDescriptionNullableParam(printWriter, "-mapEd25519PubKeySig", mapPublicFilename);
+        printRunDescriptionNullableParam(printWriter, "-mapEd25519KidSig", mapKid);
+        printRunDescriptionNullableParam(printWriter, "-mapEd25519X509CertSig", mapX509Filename);
+        printRunDescriptionNullableParam(printWriter, "-mapEd25519X5uLinkSig", mapX5uLink);
+        printRunDescriptionNullableParam(printWriter, "-sulEd25519PubKeySig", sulPublicFilename);
+        printRunDescriptionNullableParam(printWriter, "-sulEd25519KidSig", sulKid);
+        printRunDescriptionNullableParam(printWriter, "-sulEd25519X509CertSig", sulX509Filename);
+        printRunDescriptionNullableParam(printWriter, "-sulEd25519X5uLinkSig", sulX5uLink);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/Ed25519KeySigConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/Ed25519KeySigConfig.java
@@ -86,14 +86,14 @@ public class Ed25519KeySigConfig implements KeyConfig {
     @Override
     public void printRunDescriptionSelf(PrintWriter printWriter) {
         printWriter.println("### Ed25519KeySigConfig Parameters");
-        printRunDescriptionNullableParam(printWriter, "-mapEd25519PrivKeySig", mapPrivateFilename);
-        printRunDescriptionNullableParam(printWriter, "-mapEd25519PubKeySig", mapPublicFilename);
-        printRunDescriptionNullableParam(printWriter, "-mapEd25519KidSig", mapKid);
-        printRunDescriptionNullableParam(printWriter, "-mapEd25519X509CertSig", mapX509Filename);
-        printRunDescriptionNullableParam(printWriter, "-mapEd25519X5uLinkSig", mapX5uLink);
-        printRunDescriptionNullableParam(printWriter, "-sulEd25519PubKeySig", sulPublicFilename);
-        printRunDescriptionNullableParam(printWriter, "-sulEd25519KidSig", sulKid);
-        printRunDescriptionNullableParam(printWriter, "-sulEd25519X509CertSig", sulX509Filename);
-        printRunDescriptionNullableParam(printWriter, "-sulEd25519X5uLinkSig", sulX5uLink);
+        printRDStringParam(printWriter, "-mapEd25519PrivKeySig", mapPrivateFilename);
+        printRDStringParam(printWriter, "-mapEd25519PubKeySig", mapPublicFilename);
+        printRDStringParam(printWriter, "-mapEd25519KidSig", mapKid);
+        printRDStringParam(printWriter, "-mapEd25519X509CertSig", mapX509Filename);
+        printRDStringParam(printWriter, "-mapEd25519X5uLinkSig", mapX5uLink);
+        printRDStringParam(printWriter, "-sulEd25519PubKeySig", sulPublicFilename);
+        printRDStringParam(printWriter, "-sulEd25519KidSig", sulKid);
+        printRDStringParam(printWriter, "-sulEd25519X509CertSig", sulX509Filename);
+        printRDStringParam(printWriter, "-sulEd25519X5uLinkSig", sulX5uLink);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/KeyConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/KeyConfig.java
@@ -2,8 +2,6 @@ package com.github.protocolfuzzing.edhocfuzzer.components.sul.mapper.config.auth
 
 import com.github.protocolfuzzing.protocolstatefuzzer.components.learner.statistics.RunDescriptionPrinter;
 
-import java.io.PrintWriter;
-import java.util.Arrays;
 
 public interface KeyConfig extends RunDescriptionPrinter {
     public String getMapPrivateFilename();
@@ -23,17 +21,4 @@ public interface KeyConfig extends RunDescriptionPrinter {
     public String getSulX509Filename();
 
     public String getSulX5uLink();
-
-    @Override
-    default void printRunDescriptionSelf(PrintWriter printWriter) {
-        printWriter.println("Map Private Filename: " + getMapPrivateFilename());
-        printWriter.println("Map Public Filename: " + getMapPublicFilename());
-        printWriter.println("Map Kid: " + Arrays.toString(getMapKid()));
-        printWriter.println("Map X509 Filename: " + getMapX509Filename());
-        printWriter.println("Map X5u Link: " + getMapX5uLink());
-        printWriter.println("Sul Public Filename: " + getSulPublicFilename());
-        printWriter.println("Sul Kid: " + Arrays.toString(getSulKid()));
-        printWriter.println("Sul X509 Filename: " + getSulX509Filename());
-        printWriter.println("Sul X5u Link: " + getSulX5uLink());
-    }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/P256KeySigConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/P256KeySigConfig.java
@@ -85,7 +85,15 @@ public class P256KeySigConfig implements KeyConfig {
 
     @Override
     public void printRunDescriptionSelf(PrintWriter printWriter) {
-        printWriter.println("P256KeySigConfig Parameters");
-        KeyConfig.super.printRunDescriptionSelf(printWriter);
+        printWriter.println("### P256KeySigConfig Parameters");
+        printRunDescriptionNullableParam(printWriter, "-mapP256PrivKeySig", mapPrivateFilename);
+        printRunDescriptionNullableParam(printWriter, "-mapP256PubKeySig", mapPublicFilename);
+        printRunDescriptionNullableParam(printWriter, "-mapP256KidSig", mapKid);
+        printRunDescriptionNullableParam(printWriter, "-mapP256X509CertSig", mapX509Filename);
+        printRunDescriptionNullableParam(printWriter, "-mapP256X5uLinkSig", mapX5uLink);
+        printRunDescriptionNullableParam(printWriter, "-sulP256PubKeySig", sulPublicFilename);
+        printRunDescriptionNullableParam(printWriter, "-sulP256KidSig", sulKid);
+        printRunDescriptionNullableParam(printWriter, "-sulP256X509CertSig", sulX509Filename);
+        printRunDescriptionNullableParam(printWriter, "-sulP256X5uLinkSig", sulX5uLink);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/P256KeySigConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/P256KeySigConfig.java
@@ -86,14 +86,14 @@ public class P256KeySigConfig implements KeyConfig {
     @Override
     public void printRunDescriptionSelf(PrintWriter printWriter) {
         printWriter.println("### P256KeySigConfig Parameters");
-        printRunDescriptionNullableParam(printWriter, "-mapP256PrivKeySig", mapPrivateFilename);
-        printRunDescriptionNullableParam(printWriter, "-mapP256PubKeySig", mapPublicFilename);
-        printRunDescriptionNullableParam(printWriter, "-mapP256KidSig", mapKid);
-        printRunDescriptionNullableParam(printWriter, "-mapP256X509CertSig", mapX509Filename);
-        printRunDescriptionNullableParam(printWriter, "-mapP256X5uLinkSig", mapX5uLink);
-        printRunDescriptionNullableParam(printWriter, "-sulP256PubKeySig", sulPublicFilename);
-        printRunDescriptionNullableParam(printWriter, "-sulP256KidSig", sulKid);
-        printRunDescriptionNullableParam(printWriter, "-sulP256X509CertSig", sulX509Filename);
-        printRunDescriptionNullableParam(printWriter, "-sulP256X5uLinkSig", sulX5uLink);
+        printRDStringParam(printWriter, "-mapP256PrivKeySig", mapPrivateFilename);
+        printRDStringParam(printWriter, "-mapP256PubKeySig", mapPublicFilename);
+        printRDStringParam(printWriter, "-mapP256KidSig", mapKid);
+        printRDStringParam(printWriter, "-mapP256X509CertSig", mapX509Filename);
+        printRDStringParam(printWriter, "-mapP256X5uLinkSig", mapX5uLink);
+        printRDStringParam(printWriter, "-sulP256PubKeySig", sulPublicFilename);
+        printRDStringParam(printWriter, "-sulP256KidSig", sulKid);
+        printRDStringParam(printWriter, "-sulP256X509CertSig", sulX509Filename);
+        printRDStringParam(printWriter, "-sulP256X5uLinkSig", sulX5uLink);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/P256KeyStatConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/P256KeyStatConfig.java
@@ -86,14 +86,14 @@ public class P256KeyStatConfig implements KeyConfig {
     @Override
     public void printRunDescriptionSelf(PrintWriter printWriter) {
         printWriter.println("### P256KeyStatConfig Parameters");
-        printRunDescriptionNullableParam(printWriter, "-mapP256PrivKeyStat", mapPrivateFilename);
-        printRunDescriptionNullableParam(printWriter, "-mapP256PubKeyStat", mapPublicFilename);
-        printRunDescriptionNullableParam(printWriter, "-mapP256KidStat", mapKid);
-        printRunDescriptionNullableParam(printWriter, "-mapP256X509CertStat", mapX509Filename);
-        printRunDescriptionNullableParam(printWriter, "-mapP256X5uLinkStat", mapX5uLink);
-        printRunDescriptionNullableParam(printWriter, "-sulP256PubKeyStat", sulPublicFilename);
-        printRunDescriptionNullableParam(printWriter, "-sulP256KidStat", sulKid);
-        printRunDescriptionNullableParam(printWriter, "-sulP256X509CertStat", sulX509Filename);
-        printRunDescriptionNullableParam(printWriter, "-sulP256X5uLinkStat", sulX5uLink);
+        printRDStringParam(printWriter, "-mapP256PrivKeyStat", mapPrivateFilename);
+        printRDStringParam(printWriter, "-mapP256PubKeyStat", mapPublicFilename);
+        printRDStringParam(printWriter, "-mapP256KidStat", mapKid);
+        printRDStringParam(printWriter, "-mapP256X509CertStat", mapX509Filename);
+        printRDStringParam(printWriter, "-mapP256X5uLinkStat", mapX5uLink);
+        printRDStringParam(printWriter, "-sulP256PubKeyStat", sulPublicFilename);
+        printRDStringParam(printWriter, "-sulP256KidStat", sulKid);
+        printRDStringParam(printWriter, "-sulP256X509CertStat", sulX509Filename);
+        printRDStringParam(printWriter, "-sulP256X5uLinkStat", sulX5uLink);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/P256KeyStatConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/P256KeyStatConfig.java
@@ -85,7 +85,15 @@ public class P256KeyStatConfig implements KeyConfig {
 
     @Override
     public void printRunDescriptionSelf(PrintWriter printWriter) {
-        printWriter.println("P256KeyStatConfig Parameters");
-        KeyConfig.super.printRunDescriptionSelf(printWriter);
+        printWriter.println("### P256KeyStatConfig Parameters");
+        printRunDescriptionNullableParam(printWriter, "-mapP256PrivKeyStat", mapPrivateFilename);
+        printRunDescriptionNullableParam(printWriter, "-mapP256PubKeyStat", mapPublicFilename);
+        printRunDescriptionNullableParam(printWriter, "-mapP256KidStat", mapKid);
+        printRunDescriptionNullableParam(printWriter, "-mapP256X509CertStat", mapX509Filename);
+        printRunDescriptionNullableParam(printWriter, "-mapP256X5uLinkStat", mapX5uLink);
+        printRunDescriptionNullableParam(printWriter, "-sulP256PubKeyStat", sulPublicFilename);
+        printRunDescriptionNullableParam(printWriter, "-sulP256KidStat", sulKid);
+        printRunDescriptionNullableParam(printWriter, "-sulP256X509CertStat", sulX509Filename);
+        printRunDescriptionNullableParam(printWriter, "-sulP256X5uLinkStat", sulX5uLink);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/X25519KeyStatConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/X25519KeyStatConfig.java
@@ -85,14 +85,14 @@ public class X25519KeyStatConfig implements KeyConfig {
     @Override
     public void printRunDescriptionSelf(PrintWriter printWriter) {
         printWriter.println("### X25519KeyStatConfig Parameters");
-        printRunDescriptionNullableParam(printWriter, "-mapX25519PrivKeyStat", mapPrivateFilename);
-        printRunDescriptionNullableParam(printWriter, "-mapX25519PubKeyStat", mapPublicFilename);
-        printRunDescriptionNullableParam(printWriter, "-mapX25519KidStat", mapKid);
-        printRunDescriptionNullableParam(printWriter, "-mapX25519X509CertStat", mapX509Filename);
-        printRunDescriptionNullableParam(printWriter, "-mapX25519X5uLinkStat", mapX5uLink);
-        printRunDescriptionNullableParam(printWriter, "-sulX25519PubKeyStat", sulPublicFilename);
-        printRunDescriptionNullableParam(printWriter, "-sulX25519KidStat", sulKid);
-        printRunDescriptionNullableParam(printWriter, "-sulX25519X509CertStat", sulX509Filename);
-        printRunDescriptionNullableParam(printWriter, "-sulX25519X5uLinkStat", sulX5uLink);
+        printRDStringParam(printWriter, "-mapX25519PrivKeyStat", mapPrivateFilename);
+        printRDStringParam(printWriter, "-mapX25519PubKeyStat", mapPublicFilename);
+        printRDStringParam(printWriter, "-mapX25519KidStat", mapKid);
+        printRDStringParam(printWriter, "-mapX25519X509CertStat", mapX509Filename);
+        printRDStringParam(printWriter, "-mapX25519X5uLinkStat", mapX5uLink);
+        printRDStringParam(printWriter, "-sulX25519PubKeyStat", sulPublicFilename);
+        printRDStringParam(printWriter, "-sulX25519KidStat", sulKid);
+        printRDStringParam(printWriter, "-sulX25519X509CertStat", sulX509Filename);
+        printRDStringParam(printWriter, "-sulX25519X5uLinkStat", sulX5uLink);
     }
 }

--- a/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/X25519KeyStatConfig.java
+++ b/src/main/java/com/github/protocolfuzzing/edhocfuzzer/components/sul/mapper/config/authentication/keyconfigs/X25519KeyStatConfig.java
@@ -84,7 +84,15 @@ public class X25519KeyStatConfig implements KeyConfig {
 
     @Override
     public void printRunDescriptionSelf(PrintWriter printWriter) {
-        printWriter.println("X25519KeyStatConfig Parameters");
-        KeyConfig.super.printRunDescriptionSelf(printWriter);
+        printWriter.println("### X25519KeyStatConfig Parameters");
+        printRunDescriptionNullableParam(printWriter, "-mapX25519PrivKeyStat", mapPrivateFilename);
+        printRunDescriptionNullableParam(printWriter, "-mapX25519PubKeyStat", mapPublicFilename);
+        printRunDescriptionNullableParam(printWriter, "-mapX25519KidStat", mapKid);
+        printRunDescriptionNullableParam(printWriter, "-mapX25519X509CertStat", mapX509Filename);
+        printRunDescriptionNullableParam(printWriter, "-mapX25519X5uLinkStat", mapX5uLink);
+        printRunDescriptionNullableParam(printWriter, "-sulX25519PubKeyStat", sulPublicFilename);
+        printRunDescriptionNullableParam(printWriter, "-sulX25519KidStat", sulKid);
+        printRunDescriptionNullableParam(printWriter, "-sulX25519X509CertStat", sulX509Filename);
+        printRunDescriptionNullableParam(printWriter, "-sulX25519X5uLinkStat", sulX5uLink);
     }
 }


### PR DESCRIPTION
This PR updates the run description methods to conform to the PSF's update, where the output format is similar to the argument files.

One example can be seen in [this run](https://github.com/protocol-fuzzing/edhoc-fuzzer/actions/runs/26863708403/job/79222696524#step:8:698).
